### PR TITLE
Add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour
+labels: ["Bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the behaviour.
+      placeholder: |
+        1. Run `...`
+        2. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behaviour
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: dotnet_sdks
+    attributes:
+      label: dotnet --list-sdks output
+      description: Please paste the output of `dotnet --list-sdks` here.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, IDE, and any other relevant environment details.
+      placeholder: |
+        - OS: macOS 14.x / Windows 11 / Ubuntu 24.04
+        - IDE: Rider 2024.x / VS 2022
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Any relevant log output or screenshots (optional).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["Enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement to CodeToNeo4j!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the feature you'd like to see.
+      placeholder: What should be added or changed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / Use Case
+      description: Why is this feature needed? What problem does it solve?
+      placeholder: As a user, I want to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or examples that might help.
+    validations:
+      required: false

--- a/CodeToNeo4j.slnx
+++ b/CodeToNeo4j.slnx
@@ -17,6 +17,11 @@
   <Folder Name="/.src/.github/">
     <File Path=".github\release.yml" />
   </Folder>
+  <Folder Name="/.src/.github/ISSUE_TEMPLATE/">
+    <File Path=".github\ISSUE_TEMPLATE\bug_report.yml" />
+    <File Path=".github\ISSUE_TEMPLATE\config.yml" />
+    <File Path=".github\ISSUE_TEMPLATE\feature_request.yml" />
+  </Folder>
   <Folder Name="/.src/.github/scripts/">
     <File Path=".github\scripts\close-associated-issues.js" />
     <File Path=".github\scripts\test-summary-comment.js" />


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` with `Bug` label auto-applied, including a required `dotnet --list-sdks` field
- Adds `.github/ISSUE_TEMPLATE/feature_request.yml` with `Enhancement` label auto-applied
- Adds `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues

Closes #29

## Test plan

- [ ] Open a new issue on GitHub and confirm the template picker appears with both options
- [ ] Verify selecting "Bug Report" pre-applies the `Bug` label
- [ ] Verify selecting "Feature Request" pre-applies the `Enhancement` label
- [ ] Verify blank issue creation is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)