### PR TITLE
Fix release pack failing to find net8.0/net9.0 artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       run: dotnet test --no-build -c Release --verbosity normal
 
     - name: Pack
-      run: dotnet pack src/CodeToNeo4j/CodeToNeo4j.csproj --no-build -c Release -o out /p:Version=${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }}
+      run: dotnet pack src/CodeToNeo4j/CodeToNeo4j.csproj --no-restore -c Release -o out /p:Version=${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }}
 
     - name: Attest build provenance
       uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
## Summary

Replaces `--no-build` with `--no-restore` on the `dotnet pack` step in the release workflow.

**Root cause:** `dotnet build` at the solution level populates `bin/` for all target frameworks but does not fully populate `obj/` for `net8.0` and `net9.0` (only `net10.0`, which matches `Directory.Build.props`). `dotnet pack --no-build` skips the per-TFM build entirely and tries to copy directly from `obj/` — which is empty for the older frameworks, causing `MSB3030` errors.

**Fix:** Switching to `--no-restore` lets pack drive its own build for each target framework, guaranteeing all `obj/` artifacts exist, while still skipping the redundant restore step.

Closes #34

## Test plan

- [ ] Trigger the Release workflow and confirm all three TFMs (`net8.0`, `net9.0`, `net10.0`) are packed successfully
- [ ] Confirm the `.nupkg` contains tool shims for all three frameworks