### PR TITLE
Include elapsed duration in Done log message

### DIFF
--- a/src/CodeToNeo4j/Solution/SolutionProcessor.cs
+++ b/src/CodeToNeo4j/Solution/SolutionProcessor.cs
@@ -109,7 +109,13 @@ public class SolutionProcessor(
             logger.LogInformation("{FileExtension} files handled: {Count}", handler.FileExtension, handler.NumberOfFilesHandled);
         }
 
-        logger.LogInformation("Done: {Elapsed}", stopwatch.Elapsed);
+        var elapsed = stopwatch.Elapsed;
+        var duration = elapsed.TotalHours >= 1
+            ? $"{(int)elapsed.TotalHours}h {elapsed.Minutes}m {elapsed.Seconds}s"
+            : elapsed.TotalMinutes >= 1
+                ? $"{elapsed.Minutes}m {elapsed.Seconds}s"
+                : $"{elapsed.Seconds}s";
+        logger.LogInformation("Done: {Duration}", duration);
     }
 
     private async Task<(int TotalSymbols, int TotalRelationships)> RunConsumer(ChannelReader<ProcessResult> reader, int totalFiles, string databaseName, int batchSize)


### PR DESCRIPTION
## Summary

Closes #37

Starts a `Stopwatch` at the beginning of `ProcessSolution` and logs the elapsed time alongside the final `Done` message:

```
Done: 00:00:12.3456789
```

## Test plan

- [x] All existing tests pass
- [ ] Manually verify the log output shows elapsed time after a full run