### PR TITLE
Introduce ITextSymbolMapper for shared symbol construction across text-based handlers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,9 @@
 - Diff behavior between the `main` branch and your changes when relevant
 - Ask yourself: "Would a senior staff engineer approve this?"
 - Run tests, check logs, demonstrate correctness
-- Write new tests for new features and bug fixes
+- Write new tests for new features, bug fixes, and refactors — no exceptions
+- New services and classes must have dedicated unit tests (e.g. `TextSymbolMapper` → `TextSymbolMapperTests`)
+- Tests live in `tests/CodeToNeo4j.Tests/` mirroring the `src/` folder structure
 
 ### 5. Demand Elegance (Balanced)
 - For non-trivial changes: pause and ask "is there a more elegant way?"

--- a/src/CodeToNeo4j/ContainerModule.cs
+++ b/src/CodeToNeo4j/ContainerModule.cs
@@ -45,6 +45,7 @@ public static class ContainerModule
         services.AddSingleton<IFileService, FileService>();
         services.AddSingleton<IVersionControlService, GitService>();
         services.AddSingleton<ISymbolMapper, SymbolMapper>();
+        services.AddSingleton<ITextSymbolMapper, TextSymbolMapper>();
         services.AddSingleton<IDependencyIngestor, DependencyIngestor>();
         services.AddSingleton<ISolutionFileDiscoveryService, SolutionFileDiscoveryService>();
         services.AddSingleton<IRoslynSymbolProcessor, RoslynSymbolProcessor>();

--- a/src/CodeToNeo4j/FileHandlers/CsprojHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/CsprojHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace CodeToNeo4j.FileHandlers;
 
-public class CsprojHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSystem)
+public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper) : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".csproj";
 
@@ -40,7 +40,7 @@ public class CsprojHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSys
         return new FileResult(fileNamespace, fileKey);
     }
 
-    private static void ProcessProject(XElement project, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private void ProcessProject(XElement project, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility)
         {
@@ -60,24 +60,19 @@ public class CsprojHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSys
 
                 IXmlLineInfo lineInfo = property;
                 var startLine = lineInfo.HasLineInfo() ? lineInfo.LineNumber : -1;
-                var key = $"{fileKey}:Property:{name}:{startLine}";
+                var key = textSymbolMapper.BuildKey(fileKey, "Property", name, startLine);
 
-                var record = new Symbol(
-                    Key: key,
-                    Name: name,
-                    Kind: "ProjectProperty",
-                    Class: name,
-                    Fqn: $"{name}: {value}",
-                    Accessibility: "Public",
-                    FileKey: fileKey,
-                    RelativePath: relativePath,
-                    StartLine: startLine,
-                    EndLine: startLine,
-                    Documentation: value,
-                    Comments: null,
-                    Namespace: fileNamespace,
-                    Version: null
-                );
+                var record = textSymbolMapper.CreateSymbol(
+                    key: key,
+                    name: name,
+                    kind: "ProjectProperty",
+                    @class: name,
+                    fqn: $"{name}: {value}",
+                    fileKey: fileKey,
+                    relativePath: relativePath,
+                    fileNamespace: fileNamespace,
+                    startLine: startLine,
+                    documentation: value);
 
                 symbolBuffer.Add(record);
                 relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "HAS_PROPERTY"));
@@ -95,24 +90,20 @@ public class CsprojHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSys
 
             IXmlLineInfo lineInfo = packageRef;
             var startLine = lineInfo.HasLineInfo() ? lineInfo.LineNumber : -1;
-            var key = $"{fileKey}:PackageReference:{include}:{startLine}";
+            var key = textSymbolMapper.BuildKey(fileKey, "PackageReference", include, startLine);
 
-            var record = new Symbol(
-                Key: key,
-                Name: include,
-                Kind: "PackageReference",
-                Class: include,
-                Fqn: $"{include} ({version})",
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: version,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: version
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: key,
+                name: include,
+                kind: "PackageReference",
+                @class: include,
+                fqn: $"{include} ({version})",
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine,
+                documentation: version,
+                version: version);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "DEPENDS_ON"));
@@ -131,24 +122,18 @@ public class CsprojHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSys
 
             IXmlLineInfo lineInfo = projectRef;
             var startLine = lineInfo.HasLineInfo() ? lineInfo.LineNumber : -1;
-            var key = $"{fileKey}:ProjectReference:{include}:{startLine}";
+            var key = textSymbolMapper.BuildKey(fileKey, "ProjectReference", include, startLine);
 
-            var record = new Symbol(
-                Key: key,
-                Name: include,
-                Kind: "ProjectReference",
-                Class: include,
-                Fqn: include,
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: null,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: null
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: key,
+                name: include,
+                kind: "ProjectReference",
+                @class: include,
+                fqn: include,
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "DEPENDS_ON"));

--- a/src/CodeToNeo4j/FileHandlers/CssHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/CssHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 
 namespace CodeToNeo4j.FileHandlers;
 
-public partial class CssHandler (IFileSystem fileSystem) : DocumentHandlerBase(fileSystem)
+public partial class CssHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper) : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".css";
 
@@ -23,12 +23,12 @@ public partial class CssHandler (IFileSystem fileSystem) : DocumentHandlerBase(f
         var content = await GetContent(document, filePath).ConfigureAwait(false);
         var fileNamespace = Path.GetDirectoryName(relativePath)?.Replace('\\', '/');
 
-        CssHandler.ExtractSelectors(content, fileKey, relativePath, fileNamespace ?? string.Empty, symbolBuffer, relBuffer, minAccessibility);
+        ExtractSelectors(content, fileKey, relativePath, fileNamespace ?? string.Empty, symbolBuffer, relBuffer, minAccessibility);
 
         return new FileResult(fileNamespace, fileKey);
     }
 
-    private static void ExtractSelectors(string content, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private void ExtractSelectors(string content, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility) return;
 
@@ -41,24 +41,18 @@ public partial class CssHandler (IFileSystem fileSystem) : DocumentHandlerBase(f
             if (string.IsNullOrEmpty(selector) || selector.StartsWith("@")) continue;
 
             var startLine = content[..match.Index].Count(c => c == '\n') + 1;
-            var key = $"{fileKey}:CssSelector:{selector}:{startLine}";
+            var key = textSymbolMapper.BuildKey(fileKey, "CssSelector", selector, startLine);
 
-            var record = new Symbol(
-                Key: key,
-                Name: selector,
-                Kind: "CssSelector",
-                Class: "selector",
-                Fqn: selector,
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: null,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: null
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: key,
+                name: selector,
+                kind: "CssSelector",
+                @class: "selector",
+                fqn: selector,
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "CONTAINS"));

--- a/src/CodeToNeo4j/FileHandlers/HtmlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/HtmlHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 
 namespace CodeToNeo4j.FileHandlers;
 
-public partial class HtmlHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSystem)
+public partial class HtmlHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper) : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".html";
 
@@ -27,12 +27,12 @@ public partial class HtmlHandler(IFileSystem fileSystem) : DocumentHandlerBase(f
         ExtractScriptReferences(content, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
 
         // Extract IDs and Classes
-        HtmlHandler.ExtractIdsAndClasses(content, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
+        ExtractIdsAndClasses(content, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
 
         return new FileResult(fileNamespace, fileKey);
     }
 
-    private static void ExtractScriptReferences(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private void ExtractScriptReferences(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility)
         {
@@ -44,31 +44,25 @@ public partial class HtmlHandler(IFileSystem fileSystem) : DocumentHandlerBase(f
         {
             var src = match.Groups[1].Value;
             var startLine = content.Substring(0, match.Index).Count(c => c == '\n') + 1;
-            var key = $"{fileKey}:ScriptRef:{src}:{startLine}";
+            var key = textSymbolMapper.BuildKey(fileKey, "ScriptRef", src, startLine);
 
-            var record = new Symbol(
-                Key: key,
-                Name: src,
-                Kind: "HtmlScriptReference",
-                Class: "script",
-                Fqn: src,
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: null,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: null
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: key,
+                name: src,
+                kind: "HtmlScriptReference",
+                @class: "script",
+                fqn: src,
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "DEPENDS_ON"));
         }
     }
 
-    private static void ExtractIdsAndClasses(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private void ExtractIdsAndClasses(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility) return;
 
@@ -78,24 +72,18 @@ public partial class HtmlHandler(IFileSystem fileSystem) : DocumentHandlerBase(f
         {
             var id = match.Groups[1].Value;
             var startLine = content.Substring(0, match.Index).Count(c => c == '\n') + 1;
-            var key = $"{fileKey}:ElementId:{id}:{startLine}";
+            var key = textSymbolMapper.BuildKey(fileKey, "ElementId", id, startLine);
 
-            var record = new Symbol(
-                Key: key,
-                Name: id,
-                Kind: "HtmlElementId",
-                Class: "element",
-                Fqn: id,
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: null,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: null
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: key,
+                name: id,
+                kind: "HtmlElementId",
+                @class: "element",
+                fqn: id,
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "CONTAINS"));

--- a/src/CodeToNeo4j/FileHandlers/JavaScriptHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/JavaScriptHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 
 namespace CodeToNeo4j.FileHandlers;
 
-public partial class JavaScriptHandler (IFileSystem fileSystem) : DocumentHandlerBase(fileSystem)
+public partial class JavaScriptHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper) : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".js";
 
@@ -25,7 +25,7 @@ public partial class JavaScriptHandler (IFileSystem fileSystem) : DocumentHandle
 
         // Extract function definitions (basic)
         ExtractFunctions(content, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
-        
+
         // Extract imports/exports (basic)
         ExtractImportsExports(content, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
 
@@ -40,7 +40,7 @@ public partial class JavaScriptHandler (IFileSystem fileSystem) : DocumentHandle
         "return", "new", "delete", "void", "throw", "case", "in", "of", "do", "else"
     };
 
-    private static void ExtractFunctions(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private void ExtractFunctions(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility)
         {
@@ -61,24 +61,18 @@ public partial class JavaScriptHandler (IFileSystem fileSystem) : DocumentHandle
             if (string.IsNullOrEmpty(name)) continue;
 
             var startLine = content[..match.Index].Count(c => c == '\n') + 1;
-            var key = $"{fileKey}:Function:{name}:{startLine}";
+            var key = textSymbolMapper.BuildKey(fileKey, "Function", name, startLine);
 
-            var record = new Symbol(
-                Key: key,
-                Name: name,
-                Kind: "JavaScriptFunction",
-                Class: "function",
-                Fqn: name,
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: null,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: null
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: key,
+                name: name,
+                kind: "JavaScriptFunction",
+                @class: "function",
+                fqn: name,
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "CONTAINS"));
@@ -134,7 +128,7 @@ public partial class JavaScriptHandler (IFileSystem fileSystem) : DocumentHandle
         }
     }
 
-    private static void ExtractImportsExports(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private void ExtractImportsExports(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility) return;
 
@@ -144,24 +138,18 @@ public partial class JavaScriptHandler (IFileSystem fileSystem) : DocumentHandle
         {
             var module = match.Groups[1].Value;
             var startLine = content[..match.Index].Count(c => c == '\n') + 1;
-            var key = $"{fileKey}:Import:{module}:{startLine}";
+            var key = textSymbolMapper.BuildKey(fileKey, "Import", module, startLine);
 
-            var record = new Symbol(
-                Key: key,
-                Name: module,
-                Kind: "JavaScriptImport",
-                Class: "module",
-                Fqn: module,
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: null,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: null
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: key,
+                name: module,
+                kind: "JavaScriptImport",
+                @class: "module",
+                fqn: module,
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "DEPENDS_ON"));

--- a/src/CodeToNeo4j/FileHandlers/JsonHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/JsonHandler.cs
@@ -8,7 +8,8 @@ namespace CodeToNeo4j.FileHandlers;
 
 public class JsonHandler(
     IFileSystem fileSystem,
-    ILogger<JsonHandler> logger) : DocumentHandlerBase(fileSystem)
+    ILogger<JsonHandler> logger,
+    ITextSymbolMapper textSymbolMapper) : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".json";
 
@@ -39,7 +40,7 @@ public class JsonHandler(
         return new FileResult(fileNamespace, fileKey);
     }
 
-    private static void ProcessElement(JsonElement element, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility, string path)
+    private void ProcessElement(JsonElement element, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility, string path)
     {
         if (Accessibility.Public < minAccessibility)
         {
@@ -52,24 +53,18 @@ public class JsonHandler(
                 foreach (var property in element.EnumerateObject())
                 {
                     var propertyPath = string.IsNullOrEmpty(path) ? property.Name : $"{path}.{property.Name}";
-                    var key = $"{fileKey}:JsonProperty:{propertyPath}";
+                    var key = textSymbolMapper.BuildKey(fileKey, "JsonProperty", propertyPath);
 
-                    var record = new Symbol(
-                        Key: key,
-                        Name: property.Name,
-                        Kind: "JsonProperty",
-                        Class: "property",
-                        Fqn: propertyPath,
-                        Accessibility: "Public",
-                        FileKey: fileKey,
-                        RelativePath: relativePath,
-                        StartLine: -1, // System.Text.Json.JsonDocument does not provide line numbers easily
-                        EndLine: -1,
-                        Documentation: null,
-                        Comments: null,
-                        Namespace: fileNamespace,
-                        Version: null
-                    );
+                    var record = textSymbolMapper.CreateSymbol(
+                        key: key,
+                        name: property.Name,
+                        kind: "JsonProperty",
+                        @class: "property",
+                        fqn: propertyPath,
+                        fileKey: fileKey,
+                        relativePath: relativePath,
+                        fileNamespace: fileNamespace,
+                        startLine: -1); // System.Text.Json.JsonDocument does not provide line numbers easily
 
                     symbolBuffer.Add(record);
                     relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "CONTAINS"));

--- a/src/CodeToNeo4j/FileHandlers/RazorHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/RazorHandler.cs
@@ -8,7 +8,8 @@ namespace CodeToNeo4j.FileHandlers;
 
 public partial class RazorHandler(
     IRoslynSymbolProcessor symbolProcessor,
-    IFileSystem fileSystem)
+    IFileSystem fileSystem,
+    ITextSymbolMapper textSymbolMapper)
     : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".razor";
@@ -82,7 +83,7 @@ public partial class RazorHandler(
         return match.Success ? match.Groups[1].Value.Trim() : null;
     }
 
-    private static void ExtractDirectives(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private void ExtractDirectives(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility)
         {
@@ -100,25 +101,19 @@ public partial class RazorHandler(
                 line.StartsWith("@model") ? "ModelDirective" : "InheritsDirective";
 
             var name = match.Groups[1].Value.Trim();
-            var key = $"{fileKey}:{kind}:{name}";
+            var key = textSymbolMapper.BuildKey(fileKey, kind, name);
             var startLine = content[..match.Index].Count(c => c == '\n') + 1;
 
-            var record = new Symbol(
-                Key: key,
-                Name: name,
-                Kind: kind,
-                Class: "component",
-                Fqn: name,
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: null,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: null
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: key,
+                name: name,
+                kind: kind,
+                @class: "component",
+                fqn: name,
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "CONTAINS"));

--- a/src/CodeToNeo4j/FileHandlers/XamlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/XamlHandler.cs
@@ -8,7 +8,8 @@ namespace CodeToNeo4j.FileHandlers;
 
 public class XamlHandler(
     IRoslynSymbolProcessor symbolProcessor,
-    IFileSystem fileSystem)
+    IFileSystem fileSystem,
+    ITextSymbolMapper textSymbolMapper)
     : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".xaml";
@@ -35,8 +36,8 @@ public class XamlHandler(
                 var xClass = GetXamlAttribute(xdoc.Root, "Class")?.Value;
                 if (!string.IsNullOrEmpty(xClass))
                 {
-                    fileNamespace = xClass.Contains('.') 
-                        ? xClass.Substring(0, xClass.LastIndexOf('.')) 
+                    fileNamespace = xClass.Contains('.')
+                        ? xClass.Substring(0, xClass.LastIndexOf('.'))
                         : null;
                 }
 
@@ -100,25 +101,20 @@ public class XamlHandler(
         System.Xml.IXmlLineInfo lineInfo = element;
         var startLine = lineInfo.HasLineInfo() ? lineInfo.LineNumber : -1;
 
+        // XAML element keys embed the optional x:Name/x:Key suffix directly in the key
         var symbolKey = $"{fileKey}:{name}{keySuffix}:{startLine}";
         if (Accessibility.Public >= minAccessibility)
         {
-            var record = new Symbol(
-                Key: symbolKey,
-                Name: xNameAttr?.Value ?? xKeyAttr?.Value ?? name,
-                Kind: "XamlElement",
-                Class: "element",
-                Fqn: $"{name}{keySuffix}",
-                Accessibility: "Public",
-                FileKey: fileKey,
-                RelativePath: relativePath,
-                StartLine: startLine,
-                EndLine: startLine,
-                Documentation: null,
-                Comments: null,
-                Namespace: fileNamespace,
-                Version: null
-            );
+            var record = textSymbolMapper.CreateSymbol(
+                key: symbolKey,
+                name: xNameAttr?.Value ?? xKeyAttr?.Value ?? name,
+                kind: "XamlElement",
+                @class: "element",
+                fqn: $"{name}{keySuffix}",
+                fileKey: fileKey,
+                relativePath: relativePath,
+                fileNamespace: fileNamespace,
+                startLine: startLine);
 
             symbolBuffer.Add(record);
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: symbolKey, RelType: "CONTAINS"));
@@ -131,23 +127,20 @@ public class XamlHandler(
             {
                 if (Accessibility.Private >= minAccessibility)
                 {
-                    var handlerKey = $"{fileKey}:EventHandler:{attr.Value}";
-                    var handlerRecord = new Symbol(
-                        Key: handlerKey,
-                        Name: attr.Value,
-                        Kind: "XamlEventHandler",
-                        Class: "event-handler",
-                        Fqn: attr.Value,
-                        Accessibility: "Private",
-                        FileKey: fileKey,
-                        RelativePath: relativePath,
-                        StartLine: startLine,
-                        EndLine: startLine,
-                        Documentation: null,
-                        Comments: null,
-                        Namespace: fileNamespace,
-                        Version: null
-                    );
+                    var handlerKey = textSymbolMapper.BuildKey(fileKey, "EventHandler", attr.Value);
+
+                    var handlerRecord = textSymbolMapper.CreateSymbol(
+                        key: handlerKey,
+                        name: attr.Value,
+                        kind: "XamlEventHandler",
+                        @class: "event-handler",
+                        fqn: attr.Value,
+                        fileKey: fileKey,
+                        relativePath: relativePath,
+                        fileNamespace: fileNamespace,
+                        startLine: startLine,
+                        accessibility: "Private");
+
                     symbolBuffer.Add(handlerRecord);
                     relBuffer.Add(new Relationship(FromKey: symbolKey, ToKey: handlerKey, RelType: "BINDS_TO"));
                 }

--- a/src/CodeToNeo4j/FileHandlers/XmlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/XmlHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 
 namespace CodeToNeo4j.FileHandlers;
 
-public class XmlHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSystem)
+public class XmlHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper) : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".xml";
 
@@ -28,7 +28,7 @@ public class XmlHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSystem
             var xdoc = XDocument.Parse(content, LoadOptions.SetLineInfo);
             if (xdoc.Root != null)
             {
-                XmlHandler.ProcessElement(xdoc.Root, fileKey, relativePath, fileNamespace ?? string.Empty, symbolBuffer, relBuffer, minAccessibility);
+                ProcessElement(xdoc.Root, fileKey, relativePath, fileNamespace ?? string.Empty, symbolBuffer, relBuffer, minAccessibility);
             }
         }
         catch (Exception)
@@ -39,7 +39,7 @@ public class XmlHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSystem
         return new FileResult(fileNamespace, fileKey);
     }
 
-    private static void ProcessElement(XElement element, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private void ProcessElement(XElement element, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility) return;
 
@@ -47,34 +47,25 @@ public class XmlHandler(IFileSystem fileSystem) : DocumentHandlerBase(fileSystem
         System.Xml.IXmlLineInfo lineInfo = element;
         var startLine = lineInfo.HasLineInfo() ? lineInfo.LineNumber : -1;
 
-        // Create a key that is somewhat unique
-        var key = $"{fileKey}:XmlElement:{name}:{startLine}";
+        var key = textSymbolMapper.BuildKey(fileKey, "XmlElement", name, startLine);
 
-        var record = new Symbol(
-            Key: key,
-            Name: name,
-            Kind: "XmlElement",
-            Class: "element",
-            Fqn: name,
-            Accessibility: "Public",
-            FileKey: fileKey,
-            RelativePath: relativePath,
-            StartLine: startLine,
-            EndLine: startLine,
-            Documentation: null,
-            Comments: null,
-            Namespace: fileNamespace,
-            Version: null
-        );
+        var record = textSymbolMapper.CreateSymbol(
+            key: key,
+            name: name,
+            kind: "XmlElement",
+            @class: "element",
+            fqn: name,
+            fileKey: fileKey,
+            relativePath: relativePath,
+            fileNamespace: fileNamespace,
+            startLine: startLine);
 
         symbolBuffer.Add(record);
         relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "CONTAINS"));
 
-        // Only process direct children to avoid excessive depth if needed, 
-        // but here we'll do full recursion like XamlHandler.
         foreach (var child in element.Elements())
         {
-            XmlHandler.ProcessElement(child, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
+            ProcessElement(child, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
         }
     }
 }

--- a/src/CodeToNeo4j/Graph/ITextSymbolMapper.cs
+++ b/src/CodeToNeo4j/Graph/ITextSymbolMapper.cs
@@ -1,0 +1,20 @@
+namespace CodeToNeo4j.Graph;
+
+public interface ITextSymbolMapper
+{
+    string BuildKey(string fileKey, string kindToken, string name, int? startLine = null);
+
+    Symbol CreateSymbol(
+        string key,
+        string name,
+        string kind,
+        string @class,
+        string fqn,
+        string fileKey,
+        string relativePath,
+        string? fileNamespace,
+        int startLine,
+        string accessibility = "Public",
+        string? documentation = null,
+        string? version = null);
+}

--- a/src/CodeToNeo4j/Graph/TextSymbolMapper.cs
+++ b/src/CodeToNeo4j/Graph/TextSymbolMapper.cs
@@ -1,0 +1,38 @@
+namespace CodeToNeo4j.Graph;
+
+public class TextSymbolMapper : ITextSymbolMapper
+{
+    public string BuildKey(string fileKey, string kindToken, string name, int? startLine = null)
+        => startLine.HasValue
+            ? $"{fileKey}:{kindToken}:{name}:{startLine.Value}"
+            : $"{fileKey}:{kindToken}:{name}";
+
+    public Symbol CreateSymbol(
+        string key,
+        string name,
+        string kind,
+        string @class,
+        string fqn,
+        string fileKey,
+        string relativePath,
+        string? fileNamespace,
+        int startLine,
+        string accessibility = "Public",
+        string? documentation = null,
+        string? version = null)
+        => new(
+            Key: key,
+            Name: name,
+            Kind: kind,
+            Class: @class,
+            Fqn: fqn,
+            Accessibility: accessibility,
+            FileKey: fileKey,
+            RelativePath: relativePath,
+            StartLine: startLine,
+            EndLine: startLine,
+            Documentation: documentation,
+            Comments: null,
+            Namespace: fileNamespace,
+            Version: version);
+}

--- a/tests/CodeToNeo4j.Tests/FileHandlers/CsprojHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/CsprojHandlerTests.cs
@@ -14,7 +14,7 @@ public class CsprojHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CsprojHandler(fileSystem);
+        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper());
         
         var content = @"
 <Project Sdk=""Microsoft.NET.Sdk"">

--- a/tests/CodeToNeo4j.Tests/FileHandlers/CssHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/CssHandlerTests.cs
@@ -14,7 +14,7 @@ public class CssHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CssHandler(fileSystem);
+        var sut = new CssHandler(fileSystem, new TextSymbolMapper());
         var content = @"body { color: black; }";
         var filePath = "test.css";
         fileSystem.AddFile(filePath, new MockFileData(content));

--- a/tests/CodeToNeo4j.Tests/FileHandlers/HtmlHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/HtmlHandlerTests.cs
@@ -14,7 +14,7 @@ public class HtmlHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new HtmlHandler(fileSystem);
+        var sut = new HtmlHandler(fileSystem, new TextSymbolMapper());
         var content = @"
 <html>
   <head>

--- a/tests/CodeToNeo4j.Tests/FileHandlers/JavaScriptHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/JavaScriptHandlerTests.cs
@@ -14,7 +14,7 @@ public class JavaScriptHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new JavaScriptHandler(fileSystem);
+        var sut = new JavaScriptHandler(fileSystem, new TextSymbolMapper());
         var content = "function foo() {}";
         var filePath = "src/utils/test.js";
         fileSystem.AddFile(filePath, new MockFileData(content));
@@ -43,7 +43,7 @@ public class JavaScriptHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new JavaScriptHandler(fileSystem);
+        var sut = new JavaScriptHandler(fileSystem, new TextSymbolMapper());
         var content = @"
 import { foo } from './foo.js';
 function myFunction() {
@@ -89,7 +89,7 @@ const myArrow = () => {};";
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new JavaScriptHandler(fileSystem);
+        var sut = new JavaScriptHandler(fileSystem, new TextSymbolMapper());
         var content = @"
 function validate(order) {
     return order != null;
@@ -134,7 +134,7 @@ function save(order) {}";
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new JavaScriptHandler(fileSystem);
+        var sut = new JavaScriptHandler(fileSystem, new TextSymbolMapper());
         var content = "function add(a, b) { return a + b; }";
         var filePath = "test.js";
         fileSystem.AddFile(filePath, new MockFileData(content));
@@ -162,7 +162,7 @@ function save(order) {}";
     {
         // Arrange — two functions with the same name (e.g. redefinitions common in JS)
         var fileSystem = new MockFileSystem();
-        var sut = new JavaScriptHandler(fileSystem);
+        var sut = new JavaScriptHandler(fileSystem, new TextSymbolMapper());
         var content = @"
 function to(value) { return value; }
 function to(value, unit) { return value + unit; }
@@ -194,7 +194,7 @@ function caller() { to(1); }";
     {
         // Arrange — externalFn is not defined in this file
         var fileSystem = new MockFileSystem();
-        var sut = new JavaScriptHandler(fileSystem);
+        var sut = new JavaScriptHandler(fileSystem, new TextSymbolMapper());
         var content = @"
 function doWork() {
     externalFn();

--- a/tests/CodeToNeo4j.Tests/FileHandlers/JsonHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/JsonHandlerTests.cs
@@ -17,7 +17,7 @@ public class JsonHandlerTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var logger = A.Fake<ILogger<JsonHandler>>();
-        var sut = new JsonHandler(fileSystem, logger);
+        var sut = new JsonHandler(fileSystem, logger, new TextSymbolMapper());
         const string content = @"{ ""foo"": { ""bar"": 123 }, ""baz"": [1, 2] }";
         const string filePath = "test.json";
         fileSystem.AddFile(filePath, new MockFileData(content));

--- a/tests/CodeToNeo4j.Tests/FileHandlers/RazorHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/RazorHandlerTests.cs
@@ -16,7 +16,7 @@ public class RazorHandlerTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new RazorHandler(symbolProcessor, fileSystem);
+        var sut = new RazorHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"@namespace MyProject.Pages
 <h1>Hello</h1>";
         var filePath = "test.razor";
@@ -47,7 +47,7 @@ public class RazorHandlerTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new RazorHandler(symbolProcessor, fileSystem);
+        var sut = new RazorHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 @using System.Text
 @inject IMyService MyService

--- a/tests/CodeToNeo4j.Tests/FileHandlers/RazorRoslynTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/RazorRoslynTests.cs
@@ -18,7 +18,7 @@ public class RazorRoslynTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new RazorHandler(symbolProcessor, fileSystem);
+        var sut = new RazorHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         
         var razorFilePath = "Pages/Index.razor";
         var razorContent = @"@page ""/""

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlHandlerTests.cs
@@ -16,7 +16,7 @@ public class XamlHandlerTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new XamlHandler(symbolProcessor, fileSystem);
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 <Window x:Class=""MyApp.MainWindow""
         xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlNamespaceTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlNamespaceTests.cs
@@ -18,7 +18,7 @@ public class XamlNamespaceTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new XamlHandler(symbolProcessor, fileSystem);
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = $@"
 <Window x:Class=""MyApp.MainWindow""
         xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
@@ -56,7 +56,7 @@ public class XamlNamespaceTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new XamlHandler(symbolProcessor, fileSystem);
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 <ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
              xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
@@ -93,7 +93,7 @@ public class XamlNamespaceTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new XamlHandler(symbolProcessor, fileSystem);
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 <ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
              xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
@@ -130,7 +130,7 @@ public class XamlNamespaceTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new XamlHandler(symbolProcessor, fileSystem);
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 <Window xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"">
     <Button Name=""UnprefixedButton"" />

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlRoslynTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlRoslynTests.cs
@@ -18,7 +18,7 @@ public class XamlRoslynTests
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
-        var sut = new XamlHandler(symbolProcessor, fileSystem);
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         
         var xamlFilePath = "MainWindow.xaml";
         var xamlContent = @"<Window x:Class=""MyApp.MainWindow""

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XmlHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XmlHandlerTests.cs
@@ -14,7 +14,7 @@ public class XmlHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new XmlHandler(fileSystem);
+        var sut = new XmlHandler(fileSystem, new TextSymbolMapper());
         var content = @"<root><child>value</child></root>";
         var filePath = "test.xml";
         fileSystem.AddFile(filePath, new MockFileData(content));

--- a/tests/CodeToNeo4j.Tests/Graph/TextSymbolMapperTests.cs
+++ b/tests/CodeToNeo4j.Tests/Graph/TextSymbolMapperTests.cs
@@ -1,0 +1,129 @@
+using CodeToNeo4j.Graph;
+using Shouldly;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.Graph;
+
+public class TextSymbolMapperTests
+{
+    private readonly TextSymbolMapper _sut = new();
+
+    // BuildKey
+
+    [Fact]
+    public void GivenStartLine_WhenBuildKey_ThenIncludesLineInKey()
+    {
+        var key = _sut.BuildKey("file.js", "Function", "myFunc", 42);
+        key.ShouldBe("file.js:Function:myFunc:42");
+    }
+
+    [Fact]
+    public void GivenNoStartLine_WhenBuildKey_ThenOmitsLineFromKey()
+    {
+        var key = _sut.BuildKey("file.js", "Import", "./bar");
+        key.ShouldBe("file.js:Import:./bar");
+    }
+
+    [Fact]
+    public void GivenNullStartLine_WhenBuildKey_ThenOmitsLineFromKey()
+    {
+        var key = _sut.BuildKey("file.js", "Kind", "name", null);
+        key.ShouldBe("file.js:Kind:name");
+    }
+
+    // CreateSymbol — enforced invariants
+
+    [Fact]
+    public void GivenStartLine_WhenCreateSymbol_ThenEndLineEqualsStartLine()
+    {
+        var symbol = BuildSymbol(startLine: 7);
+        symbol.EndLine.ShouldBe(symbol.StartLine);
+    }
+
+    [Fact]
+    public void WhenCreateSymbol_ThenCommentsIsAlwaysNull()
+    {
+        var symbol = BuildSymbol();
+        symbol.Comments.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNoAccessibility_WhenCreateSymbol_ThenDefaultsToPublic()
+    {
+        var symbol = BuildSymbol();
+        symbol.Accessibility.ShouldBe("Public");
+    }
+
+    [Fact]
+    public void GivenExplicitAccessibility_WhenCreateSymbol_ThenUsesProvidedValue()
+    {
+        var symbol = BuildSymbol(accessibility: "Private");
+        symbol.Accessibility.ShouldBe("Private");
+    }
+
+    [Fact]
+    public void GivenDocumentation_WhenCreateSymbol_ThenDocumentationIsSet()
+    {
+        var symbol = BuildSymbol(documentation: "some docs");
+        symbol.Documentation.ShouldBe("some docs");
+    }
+
+    [Fact]
+    public void GivenNoDocumentation_WhenCreateSymbol_ThenDocumentationIsNull()
+    {
+        var symbol = BuildSymbol();
+        symbol.Documentation.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenVersion_WhenCreateSymbol_ThenVersionIsSet()
+    {
+        var symbol = BuildSymbol(version: "1.2.3");
+        symbol.Version.ShouldBe("1.2.3");
+    }
+
+    [Fact]
+    public void GivenAllCoreFields_WhenCreateSymbol_ThenFieldsAreSetCorrectly()
+    {
+        var symbol = _sut.CreateSymbol(
+            key: "file.js:Function:foo:5",
+            name: "foo",
+            kind: "JavaScriptFunction",
+            @class: "function",
+            fqn: "foo",
+            fileKey: "file.js",
+            relativePath: "src/file.js",
+            fileNamespace: "src",
+            startLine: 5);
+
+        symbol.Key.ShouldBe("file.js:Function:foo:5");
+        symbol.Name.ShouldBe("foo");
+        symbol.Kind.ShouldBe("JavaScriptFunction");
+        symbol.Class.ShouldBe("function");
+        symbol.Fqn.ShouldBe("foo");
+        symbol.FileKey.ShouldBe("file.js");
+        symbol.RelativePath.ShouldBe("src/file.js");
+        symbol.Namespace.ShouldBe("src");
+        symbol.StartLine.ShouldBe(5);
+        symbol.EndLine.ShouldBe(5);
+    }
+
+    private Symbol BuildSymbol(
+        int startLine = 1,
+        string accessibility = "Public",
+        string? documentation = null,
+        string? version = null)
+        => _sut.CreateSymbol(
+            key: "file:Kind:name:1",
+            name: "name",
+            kind: "Kind",
+            @class: "class",
+            fqn: "name",
+            fileKey: "file",
+            relativePath: "file",
+            fileNamespace: null,
+            startLine: startLine,
+            accessibility: accessibility,
+            documentation: documentation,
+            version: version);
+}


### PR DESCRIPTION
## Summary

- Introduces `ITextSymbolMapper` / `TextSymbolMapper` in `Graph/` to centralize `Symbol` record construction and key formatting for all text-based (non-Roslyn) file handlers
- All 8 text-based handlers (`JavaScriptHandler`, `HtmlHandler`, `CssHandler`, `XmlHandler`, `JsonHandler`, `CsprojHandler`, `XamlHandler`, `RazorHandler`) now inject `ITextSymbolMapper` instead of building `Symbol` records inline
- Enforces invariants in one place: `EndLine = StartLine`, `Comments = null`, default `Accessibility = "Public"`
- Registered `ITextSymbolMapper` → `TextSymbolMapper` as a singleton in `ContainerModule`

Closes #40

## Test plan

- [x] `TextSymbolMapperTests` — 11 unit tests covering `BuildKey` (with/without line), `CreateSymbol` invariants (EndLine, Comments, Accessibility, Documentation, Version)
- [x] All existing handler tests updated to pass `new TextSymbolMapper()` and continue to pass (102 total tests passing)