### PR TITLE
Log version as first message on every run

### DIFF
--- a/src/CodeToNeo4j/Program.cs
+++ b/src/CodeToNeo4j/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using System.Reflection;
 using CodeToNeo4j.ProgramOptions;
 using CodeToNeo4j.ProgramOptions.Handlers;
 using Microsoft.Extensions.Logging;
@@ -108,6 +109,7 @@ public class Program
                     .BuildServiceProvider();
 
                 var logger = services.GetRequiredService<ILogger<Program>>();
+                logger.LogInformation("CodeToNeo4j version {Version}", GetVersion());
                 logger.LogInformation("{Options}", options);
                 var handlers = services.GetRequiredService<IEnumerable<IOptionsHandler>>();
                 await handlers.BuildChain().Handle(options);
@@ -116,6 +118,11 @@ public class Program
 
         return (root, binder);
     }
+
+    internal static string GetVersion() =>
+        typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(Program).Assembly.GetName().Version?.ToString()
+        ?? "unknown";
 
     private static async Task<int> Run(string[] args)
     {

--- a/tests/CodeToNeo4j.Tests/ProgramTests.cs
+++ b/tests/CodeToNeo4j.Tests/ProgramTests.cs
@@ -135,4 +135,14 @@ public class ProgramTests
         // assert
         result.Errors.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void GivenAssembly_WhenGettingVersion_ThenVersionIsNotNullOrEmpty()
+    {
+        // act
+        var version = Program.GetVersion();
+
+        // assert
+        version.ShouldNotBeNullOrWhiteSpace();
+    }
 }


### PR DESCRIPTION
## Summary

Log the assembly's informational version as the first `LogInformation` call in `Program.cs` before any other work begins. Adds a `GetVersion()` helper on `Program` (reads `AssemblyInformationalVersionAttribute`, falling back to `AssemblyName.Version`) and a unit test to verify it returns a non-empty string.

## Issue

Resolves #49

## Checklist

- [x] This PR resolves the linked issue