### PR TITLE
Enrich NuGet dependency nodes with .nuspec metadata

### DIFF
--- a/src/CodeToNeo4j/Cypher/Queries.cs
+++ b/src/CodeToNeo4j/Cypher/Queries.cs
@@ -14,4 +14,5 @@ public static class Queries
     public const string UpsertDependencies = "UpsertDependencies";
     public const string PurgeData = "PurgeData";
     public const string UpsertTags = "UpsertTags";
+    public const string UpsertDependencyUrls = "UpsertDependencyUrls";
 }

--- a/src/CodeToNeo4j/Cypher/Schema.cypher
+++ b/src/CodeToNeo4j/Cypher/Schema.cypher
@@ -46,3 +46,9 @@ FOR (c:Commit) ON (c.date);
 
 CREATE CONSTRAINT tag_name IF NOT EXISTS
 FOR (t:Tag) REQUIRE t.name IS UNIQUE;
+
+CREATE CONSTRAINT url_key IF NOT EXISTS
+FOR (u:Url) REQUIRE u.key IS UNIQUE;
+
+CREATE INDEX url_name IF NOT EXISTS
+FOR (u:Url) ON (u.name);

--- a/src/CodeToNeo4j/Cypher/UpsertDependencyUrls.cypher
+++ b/src/CodeToNeo4j/Cypher/UpsertDependencyUrls.cypher
@@ -1,0 +1,8 @@
+UNWIND $urls AS u
+MERGE (url:Url {key: u.urlKey})
+SET url.name = u.name,
+    url.updatedAt = datetime(),
+    url.CodeToNeo4j = true
+WITH url, u
+MATCH (dep:Dependency {key: u.depKey})
+MERGE (dep)-[:HAS_URL]->(url)

--- a/src/CodeToNeo4j/FileHandlers/CsprojHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/CsprojHandler.cs
@@ -26,13 +26,14 @@ public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolM
     {
         var content = await GetContent(document, filePath).ConfigureAwait(false);
         var fileNamespace = Path.GetDirectoryName(relativePath)?.Replace('\\', '/');
+        var urlNodes = new List<UrlNode>();
 
         try
         {
             var xdoc = XDocument.Parse(content, LoadOptions.SetLineInfo);
             if (xdoc.Root != null)
             {
-                await ProcessProject(xdoc.Root, fileKey, relativePath, fileNamespace ?? string.Empty, symbolBuffer, relBuffer, minAccessibility).ConfigureAwait(false);
+                await ProcessProject(xdoc.Root, fileKey, relativePath, fileNamespace ?? string.Empty, symbolBuffer, relBuffer, urlNodes, minAccessibility).ConfigureAwait(false);
             }
         }
         catch (Exception)
@@ -40,10 +41,10 @@ public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolM
             // Fail gracefully
         }
 
-        return new FileResult(fileNamespace, fileKey);
+        return new FileResult(fileNamespace, fileKey, urlNodes.Count > 0 ? urlNodes : null);
     }
 
-    private async Task ProcessProject(XElement project, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
+    private async Task ProcessProject(XElement project, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, List<UrlNode> urlNodes, Accessibility minAccessibility)
     {
         if (Accessibility.Public < minAccessibility)
         {
@@ -92,7 +93,7 @@ public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolM
             if (string.IsNullOrEmpty(include)) continue;
 
             AddDependency(include, version, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer);
-            await AddNuspecUrls(include, version, symbolBuffer, relBuffer).ConfigureAwait(false);
+            await CollectNuspecUrls(include, version, urlNodes).ConfigureAwait(false);
         }
 
         // Extract ProjectReferences
@@ -126,42 +127,16 @@ public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolM
         }
     }
 
-    private async Task AddNuspecUrls(string name, string? version, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer)
+    private async Task CollectNuspecUrls(string name, string? version, List<UrlNode> urlNodes)
     {
         var (projectUrl, repositoryUrl) = await TryGetNuspecMetadataAsync(name, version).ConfigureAwait(false);
         var depKey = $"pkg:{name}";
 
         if (!string.IsNullOrEmpty(projectUrl))
-        {
-            var urlKey = $"url:{projectUrl}";
-            symbolBuffer.Add(SymbolMapper.CreateSymbol(
-                key: urlKey,
-                name: projectUrl,
-                kind: "Url",
-                @class: "Url",
-                fqn: projectUrl,
-                fileKey: depKey,
-                relativePath: string.Empty,
-                fileNamespace: null,
-                startLine: -1));
-            relBuffer.Add(new Relationship(FromKey: depKey, ToKey: urlKey, RelType: "HAS_URL"));
-        }
+            urlNodes.Add(new UrlNode(depKey, $"url:{projectUrl}", projectUrl));
 
         if (!string.IsNullOrEmpty(repositoryUrl))
-        {
-            var urlKey = $"url:{repositoryUrl}";
-            symbolBuffer.Add(SymbolMapper.CreateSymbol(
-                key: urlKey,
-                name: repositoryUrl,
-                kind: "Url",
-                @class: "Url",
-                fqn: repositoryUrl,
-                fileKey: depKey,
-                relativePath: string.Empty,
-                fileNamespace: null,
-                startLine: -1));
-            relBuffer.Add(new Relationship(FromKey: depKey, ToKey: urlKey, RelType: "HAS_URL"));
-        }
+            urlNodes.Add(new UrlNode(depKey, $"url:{repositoryUrl}", repositoryUrl));
     }
 
     private async Task<(string? ProjectUrl, string? RepositoryUrl)> TryGetNuspecMetadataAsync(string name, string? version)

--- a/src/CodeToNeo4j/Graph/FileResult.cs
+++ b/src/CodeToNeo4j/Graph/FileResult.cs
@@ -1,3 +1,3 @@
 namespace CodeToNeo4j.Graph;
 
-public record FileResult(string? Namespace, string? FileKey);
+public record FileResult(string? Namespace, string? FileKey, IReadOnlyCollection<UrlNode>? UrlNodes = null);

--- a/src/CodeToNeo4j/Graph/IGraphService.cs
+++ b/src/CodeToNeo4j/Graph/IGraphService.cs
@@ -10,5 +10,6 @@ public interface IGraphService
     Task UpsertDependencies(string? repoKey, IEnumerable<Dependency> dependencies, string databaseName);
     Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName);
     Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName);
+    Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName);
     Task PurgeData(string? repoKey, IEnumerable<string>? includeExtensions, string databaseName, bool purgeDependencies, int batchSize);
 }

--- a/src/CodeToNeo4j/Graph/UrlNode.cs
+++ b/src/CodeToNeo4j/Graph/UrlNode.cs
@@ -1,0 +1,7 @@
+namespace CodeToNeo4j.Graph;
+
+public record UrlNode(
+    string DepKey,
+    string UrlKey,
+    string Name
+);

--- a/src/CodeToNeo4j/Neo4j/Neo4jService.cs
+++ b/src/CodeToNeo4j/Neo4j/Neo4jService.cs
@@ -233,6 +233,23 @@ public class Neo4jService(
         }
     }
 
+    public async Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName)
+    {
+        var urlBatch = urlNodes.Select(u => new Dictionary<string, object?>
+        {
+            ["depKey"] = u.DepKey,
+            ["urlKey"] = u.UrlKey,
+            ["name"] = u.Name
+        }).ToArray();
+
+        if (urlBatch.Length == 0) return;
+
+        logger.LogDebug("Upserting {Count} dependency URL nodes in database: {DatabaseName}", urlBatch.Length, databaseName);
+        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
+        await session.ExecuteWriteAsync(async tx => await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertDependencyUrls), new { urls = urlBatch }))
+            .ConfigureAwait(false);
+    }
+
     public async Task PurgeData(string? repoKey, IEnumerable<string>? includeExtensions, string databaseName, bool purgeDependencies, int batchSize)
     {
         var purgeTarget = repoKey is null ? "ALL CodeToNeo4j data" : $"repoKey '{repoKey}'";

--- a/src/CodeToNeo4j/Solution/SolutionProcessor.cs
+++ b/src/CodeToNeo4j/Solution/SolutionProcessor.cs
@@ -123,6 +123,7 @@ public class SolutionProcessor(
         var fileBuffer = new List<FileMetaData>(batchSize);
         var symbolBuffer = new List<Symbol>(batchSize);
         var relBuffer = new List<Relationship>(batchSize);
+        var urlBuffer = new List<UrlNode>(batchSize);
         var currentFileIndex = 0;
         var totalSymbols = 0;
         var totalRelationships = 0;
@@ -132,27 +133,28 @@ public class SolutionProcessor(
             fileBuffer.Add(result.File);
             symbolBuffer.AddRange(result.Symbols);
             relBuffer.AddRange(result.Relationships);
+            urlBuffer.AddRange(result.UrlNodes);
 
             totalSymbols += result.Symbols.Count;
             totalRelationships += result.Relationships.Count;
 
             if (fileBuffer.Count >= batchSize || symbolBuffer.Count >= batchSize)
             {
-                await FlushBuffers(fileBuffer, symbolBuffer, relBuffer, databaseName).ConfigureAwait(false);
+                await FlushBuffers(fileBuffer, symbolBuffer, relBuffer, urlBuffer, databaseName).ConfigureAwait(false);
             }
 
             progressService.ReportProgress(++currentFileIndex, totalFiles, result.RelativePath);
         }
 
-        if (fileBuffer.Count > 0 || symbolBuffer.Count > 0)
+        if (fileBuffer.Count > 0 || symbolBuffer.Count > 0 || urlBuffer.Count > 0)
         {
-            await FlushBuffers(fileBuffer, symbolBuffer, relBuffer, databaseName).ConfigureAwait(false);
+            await FlushBuffers(fileBuffer, symbolBuffer, relBuffer, urlBuffer, databaseName).ConfigureAwait(false);
         }
 
         return (totalSymbols, totalRelationships);
     }
 
-    private async Task FlushBuffers(List<FileMetaData> files, List<Symbol> symbols, List<Relationship> relationships, string databaseName)
+    private async Task FlushBuffers(List<FileMetaData> files, List<Symbol> symbols, List<Relationship> relationships, List<UrlNode> urlNodes, string databaseName)
     {
         if (files.Count > 0)
         {
@@ -165,6 +167,12 @@ public class SolutionProcessor(
             await graphService.FlushSymbols(symbols, relationships, databaseName).ConfigureAwait(false);
             symbols.Clear();
             relationships.Clear();
+        }
+
+        if (urlNodes.Count > 0)
+        {
+            await graphService.UpsertDependencyUrls(urlNodes, databaseName).ConfigureAwait(false);
+            urlNodes.Clear();
         }
     }
 
@@ -251,15 +259,17 @@ public class SolutionProcessor(
 
         var finalFileKey = fileResult?.FileKey ?? fileKey;
         var finalNamespace = fileResult?.Namespace ?? defaultNamespace;
+        var urlNodes = fileResult?.UrlNodes is { Count: > 0 } urls ? urls.ToList() : [];
 
         var fileRecord = new FileMetaData(finalFileKey, fileName, relativePath, fileHash, metadata, repoKey, finalNamespace);
 
-        return new ProcessResult(fileRecord, symbols, relationships, relativePath);
+        return new ProcessResult(fileRecord, symbols, relationships, urlNodes, relativePath);
     }
 
     private record ProcessResult(
         FileMetaData File,
         List<Symbol> Symbols,
         List<Relationship> Relationships,
+        List<UrlNode> UrlNodes,
         string RelativePath);
 }

--- a/tests/CodeToNeo4j.Tests/FileHandlers/CsprojHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/CsprojHandlerTests.cs
@@ -44,13 +44,11 @@ public class CsprojHandlerTests
             minAccessibility: Accessibility.Private);
 
         // Assert
-        // Check for Property
         var propertySymbol = symbolBuffer.FirstOrDefault(s => s.Name == "TargetFramework");
         propertySymbol.ShouldNotBeNull();
         propertySymbol.Kind.ShouldBe("ProjectProperty");
         propertySymbol.Documentation.ShouldBe("net8.0");
 
-        // Check for Dependency (package reference unified as Dependency node)
         var packageSymbol = symbolBuffer.FirstOrDefault(s => s.Name == "Newtonsoft.Json");
         packageSymbol.ShouldNotBeNull();
         packageSymbol.Key.ShouldBe("pkg:Newtonsoft.Json");
@@ -58,19 +56,17 @@ public class CsprojHandlerTests
         packageSymbol.Documentation.ShouldBe("13.0.1");
         packageSymbol.Version.ShouldBe("13.0.1");
 
-        // Check for ProjectReference
         var projectSymbol = symbolBuffer.FirstOrDefault(s => s.Name == @"..\MyLib\MyLib.csproj");
         projectSymbol.ShouldNotBeNull();
         projectSymbol.Kind.ShouldBe("ProjectReference");
 
-        // Check relationships
         relBuffer.ShouldContain(r => r.FromKey == "test-file" && r.ToKey == propertySymbol.Key && r.RelType == "HAS_PROPERTY");
         relBuffer.ShouldContain(r => r.FromKey == "test-file" && r.ToKey == packageSymbol.Key && r.RelType == "DEPENDS_ON");
         relBuffer.ShouldContain(r => r.FromKey == "test-file" && r.ToKey == projectSymbol.Key && r.RelType == "DEPENDS_ON");
     }
 
     [Fact]
-    public async Task GivenPackageReference_AndNuspecHasBothUrls_WhenHandled_ThenCreatesUrlSymbolsAndRelationships()
+    public async Task GivenPackageReference_AndNuspecHasBothUrls_WhenHandled_ThenReturnsUrlNodesInFileResult()
     {
         // Arrange
         var fileSystem = new MockFileSystem();
@@ -99,35 +95,34 @@ public class CsprojHandlerTests
         var relBuffer = new List<Relationship>();
 
         // Act
-        await sut.Handle(
+        var result = await sut.Handle(
             document: null, compilation: null,
             repoKey: "test-repo", fileKey: "test-file",
             filePath: filePath, relativePath: filePath,
             symbolBuffer: symbolBuffer, relBuffer: relBuffer,
             minAccessibility: Accessibility.Private);
 
-        // Assert
-        var projectUrlSymbol = symbolBuffer.FirstOrDefault(s => s.Kind == "Url" && s.Name == "https://www.newtonsoft.com/json");
-        projectUrlSymbol.ShouldNotBeNull();
-        projectUrlSymbol.Key.ShouldBe("url:https://www.newtonsoft.com/json");
-        projectUrlSymbol.Class.ShouldBe("Url");
+        // Assert — URL data is in FileResult, not in the symbol/rel buffers
+        result.UrlNodes.ShouldNotBeNull();
+        result.UrlNodes.Count.ShouldBe(2);
 
-        var repoUrlSymbol = symbolBuffer.FirstOrDefault(s => s.Kind == "Url" && s.Name == "https://github.com/JamesNK/Newtonsoft.Json");
-        repoUrlSymbol.ShouldNotBeNull();
-        repoUrlSymbol.Key.ShouldBe("url:https://github.com/JamesNK/Newtonsoft.Json");
+        var projectUrlNode = result.UrlNodes.FirstOrDefault(u => u.Name == "https://www.newtonsoft.com/json");
+        projectUrlNode.ShouldNotBeNull();
+        projectUrlNode.DepKey.ShouldBe("pkg:Newtonsoft.Json");
+        projectUrlNode.UrlKey.ShouldBe("url:https://www.newtonsoft.com/json");
 
-        relBuffer.ShouldContain(r =>
-            r.FromKey == "pkg:Newtonsoft.Json" &&
-            r.ToKey == "url:https://www.newtonsoft.com/json" &&
-            r.RelType == "HAS_URL");
-        relBuffer.ShouldContain(r =>
-            r.FromKey == "pkg:Newtonsoft.Json" &&
-            r.ToKey == "url:https://github.com/JamesNK/Newtonsoft.Json" &&
-            r.RelType == "HAS_URL");
+        var repoUrlNode = result.UrlNodes.FirstOrDefault(u => u.Name == "https://github.com/JamesNK/Newtonsoft.Json");
+        repoUrlNode.ShouldNotBeNull();
+        repoUrlNode.DepKey.ShouldBe("pkg:Newtonsoft.Json");
+        repoUrlNode.UrlKey.ShouldBe("url:https://github.com/JamesNK/Newtonsoft.Json");
+
+        // URL data must NOT appear in the symbol or relationship buffers
+        symbolBuffer.ShouldNotContain(s => s.Kind == "Url");
+        relBuffer.ShouldNotContain(r => r.RelType == "HAS_URL");
     }
 
     [Fact]
-    public async Task GivenPackageReference_AndNuspecHasOnlyProjectUrl_WhenHandled_ThenOnlyOneUrlRelationship()
+    public async Task GivenPackageReference_AndNuspecHasOnlyProjectUrl_WhenHandled_ThenReturnsOneUrlNode()
     {
         // Arrange
         var fileSystem = new MockFileSystem();
@@ -155,7 +150,7 @@ public class CsprojHandlerTests
         var relBuffer = new List<Relationship>();
 
         // Act
-        await sut.Handle(
+        var result = await sut.Handle(
             document: null, compilation: null,
             repoKey: "test-repo", fileKey: "test-file",
             filePath: filePath, relativePath: filePath,
@@ -163,13 +158,13 @@ public class CsprojHandlerTests
             minAccessibility: Accessibility.Private);
 
         // Assert
-        symbolBuffer.Count(s => s.Kind == "Url").ShouldBe(1);
-        relBuffer.Count(r => r.RelType == "HAS_URL").ShouldBe(1);
-        relBuffer.ShouldContain(r => r.ToKey == "url:https://serilog.net" && r.RelType == "HAS_URL");
+        result.UrlNodes.ShouldNotBeNull();
+        result.UrlNodes.Count.ShouldBe(1);
+        result.UrlNodes.First().UrlKey.ShouldBe("url:https://serilog.net");
     }
 
     [Fact]
-    public async Task GivenPackageReference_AndNuspecHasOnlyRepositoryUrl_WhenHandled_ThenOnlyOneUrlRelationship()
+    public async Task GivenPackageReference_AndNuspecHasOnlyRepositoryUrl_WhenHandled_ThenReturnsOneUrlNode()
     {
         // Arrange
         var fileSystem = new MockFileSystem();
@@ -197,7 +192,7 @@ public class CsprojHandlerTests
         var relBuffer = new List<Relationship>();
 
         // Act
-        await sut.Handle(
+        var result = await sut.Handle(
             document: null, compilation: null,
             repoKey: "test-repo", fileKey: "test-file",
             filePath: filePath, relativePath: filePath,
@@ -205,13 +200,13 @@ public class CsprojHandlerTests
             minAccessibility: Accessibility.Private);
 
         // Assert
-        symbolBuffer.Count(s => s.Kind == "Url").ShouldBe(1);
-        relBuffer.Count(r => r.RelType == "HAS_URL").ShouldBe(1);
-        relBuffer.ShouldContain(r => r.ToKey == "url:https://github.com/org/mylib" && r.RelType == "HAS_URL");
+        result.UrlNodes.ShouldNotBeNull();
+        result.UrlNodes.Count.ShouldBe(1);
+        result.UrlNodes.First().UrlKey.ShouldBe("url:https://github.com/org/mylib");
     }
 
     [Fact]
-    public async Task GivenPackageReference_AndNuspecIsMissing_WhenHandled_ThenNoUrlSymbols()
+    public async Task GivenPackageReference_AndNuspecIsMissing_WhenHandled_ThenNoUrlNodes()
     {
         // Arrange
         var fileSystem = new MockFileSystem();
@@ -230,7 +225,7 @@ public class CsprojHandlerTests
         var relBuffer = new List<Relationship>();
 
         // Act
-        await sut.Handle(
+        var result = await sut.Handle(
             document: null, compilation: null,
             repoKey: "test-repo", fileKey: "test-file",
             filePath: filePath, relativePath: filePath,
@@ -238,13 +233,11 @@ public class CsprojHandlerTests
             minAccessibility: Accessibility.Private);
 
         // Assert
-        symbolBuffer.ShouldNotContain(s => s.Kind == "Url");
-        relBuffer.ShouldNotContain(r => r.RelType == "HAS_URL");
-        relBuffer.ShouldNotContain(r => r.RelType == "HAS_URL");
+        result.UrlNodes.ShouldBeNull();
     }
 
     [Fact]
-    public async Task GivenPackageReference_AndNuspecIsMalformed_WhenHandled_ThenNoUrlSymbolsAndNoException()
+    public async Task GivenPackageReference_AndNuspecIsMalformed_WhenHandled_ThenNoUrlNodesAndNoException()
     {
         // Arrange
         var fileSystem = new MockFileSystem();
@@ -262,8 +255,8 @@ public class CsprojHandlerTests
         var symbolBuffer = new List<Symbol>();
         var relBuffer = new List<Relationship>();
 
-        // Act - should not throw
-        await sut.Handle(
+        // Act — should not throw
+        var result = await sut.Handle(
             document: null, compilation: null,
             repoKey: "test-repo", fileKey: "test-file",
             filePath: filePath, relativePath: filePath,
@@ -271,13 +264,11 @@ public class CsprojHandlerTests
             minAccessibility: Accessibility.Private);
 
         // Assert
-        symbolBuffer.ShouldNotContain(s => s.Kind == "Url");
-        relBuffer.ShouldNotContain(r => r.RelType == "HAS_URL");
-        relBuffer.ShouldNotContain(r => r.RelType == "HAS_URL");
+        result.UrlNodes.ShouldBeNull();
     }
 
     [Fact]
-    public async Task GivenPackageReferenceWithNoVersion_WhenHandled_ThenNoUrlSymbols()
+    public async Task GivenPackageReferenceWithNoVersion_WhenHandled_ThenNoUrlNodes()
     {
         // Arrange
         var fileSystem = new MockFileSystem();
@@ -295,7 +286,7 @@ public class CsprojHandlerTests
         var relBuffer = new List<Relationship>();
 
         // Act
-        await sut.Handle(
+        var result = await sut.Handle(
             document: null, compilation: null,
             repoKey: "test-repo", fileKey: "test-file",
             filePath: filePath, relativePath: filePath,
@@ -303,7 +294,7 @@ public class CsprojHandlerTests
             minAccessibility: Accessibility.Private);
 
         // Assert
-        symbolBuffer.ShouldNotContain(s => s.Kind == "Url");
+        result.UrlNodes.ShouldBeNull();
     }
 
     private static string NuspecPath(string name, string version)


### PR DESCRIPTION
## Summary

- For each `PackageReference` in a `.csproj`, locate the corresponding `.nuspec` in the NuGet global packages cache (`~/.nuget/packages/{name}/{version}/{name}.nuspec`)
- Parse `<projectUrl>` and `<repository url="...">` from the manifest
- Emit `Url` nodes (Symbol kind `"Url"`) and `HAS_PROJECT_URL` / `HAS_REPOSITORY_URL` relationships from the `Dependency` node to each URL
- Missing or malformed `.nuspec` files are silently skipped

## Issue

Resolves #48

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change