### PR TITLE
Add --version, --supported-files, and --info CLI switches

### DIFF
--- a/.agent/INSTRUCTIONS.md
+++ b/.agent/INSTRUCTIONS.md
@@ -53,3 +53,5 @@
     2. If the branch already contains the issue number, you are already in the right place — git cannot check out the same branch in two worktrees, so just work in the current directory.
     3. If not, pull the latest `main` first, then create a new branch in the worktree: `git checkout main && git pull && git worktree add ../<repo>-issue-{number} -b users/CFlorell/story/{issue-number}`
     4. Do all implementation work inside the worktree directory.
+    5. After each change, commit with a descriptive (but short) message, and then rebase the `main` branch.
+    6. When ready to submit a pull request, ensure that the branch is up-to-date with `main` and that all tests pass before pushing.

--- a/src/CodeToNeo4j/Program.cs
+++ b/src/CodeToNeo4j/Program.cs
@@ -1,4 +1,6 @@
-﻿using System.CommandLine;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
 using System.Reflection;
 using CodeToNeo4j.ProgramOptions;
 using CodeToNeo4j.ProgramOptions.Handlers;
@@ -10,6 +12,22 @@ namespace CodeToNeo4j;
 
 public class Program
 {
+    // Each entry is (Extension/Pattern, HandlerName) — kept in sync with ContainerModule handler registrations.
+    internal static readonly (string Extension, string HandlerName)[] SupportedFileTypes =
+    [
+        (".cs",           "CSharpHandler"),
+        (".razor",        "RazorHandler"),
+        (".xaml",         "XamlHandler"),
+        (".js",           "JavaScriptHandler"),
+        (".ts / .tsx",    "TypeScriptHandler"),
+        (".html",         "HtmlHandler"),
+        (".xml",          "XmlHandler"),
+        ("package.json",  "PackageJsonHandler"),
+        (".json",         "JsonHandler"),
+        (".css",          "CssHandler"),
+        (".csproj",       "CsprojHandler"),
+    ];
+
     public static async Task<int> Main(string[] args)
     {
         try
@@ -36,7 +54,6 @@ public class Program
             .WithAlias("-s")
             .WithDescription("Path to the .sln file to index. Example: ./MySolution.sln");
         var passOption = new Option<string>("--password")
-            .IsRequired()
             .WithDescription("Password for the Neo4j database. Example: your-pass")
             .WithAlias("-p");
         var noKeyOption = new Option<bool>("--no-key")
@@ -80,7 +97,12 @@ public class Program
         var purgeDataOption = new Option<bool>("--purge-data")
             .WithDefaultValueFunc(() => false)
             .WithDescription("Purge all data from Neo4j associated with the specified repository key. Example: --purge-data");
-
+        var showVersionOption = new Option<bool>("--version")
+            .WithDescription("Print the current tool version and exit.");
+        var showSupportedFilesOption = new Option<bool>("--supported-files")
+            .WithDescription("Print a table of all supported file types and exit.");
+        var showInfoOption = new Option<bool>("--info")
+            .WithDescription("Print the version and all supported file types, then exit.");
 
         var binder = new OptionsBinder(
             slnOption,
@@ -98,14 +120,31 @@ public class Program
             quietOption,
             skipDependenciesOption,
             purgeDataOption,
-            includeExtensionsOption);
+            includeExtensionsOption,
+            showVersionOption,
+            showSupportedFilesOption,
+            showInfoOption);
 
         var root = new RootCommand("Index .NET solution into Neo4j via Roslyn");
+
         binder.AddToCommand(root);
         root.SetHandler(async options =>
             {
+                if (options.ShowVersion || options.ShowInfo)
+                {
+                    Console.WriteLine($"CodeToNeo4j {GetVersion()}");
+                }
+
+                if (options.ShowSupportedFiles || options.ShowInfo)
+                {
+                    PrintSupportedFiles();
+                }
+
+                if (options.ShowVersion || options.ShowSupportedFiles || options.ShowInfo)
+                    return;
+
                 await using var services = new ServiceCollection()
-                    .AddApplicationServices(options.Uri, options.User, options.Pass, options.LogLevel)
+                    .AddApplicationServices(options.Uri, options.User, options.Pass!, options.LogLevel)
                     .BuildServiceProvider();
 
                 var logger = services.GetRequiredService<ILogger<Program>>();
@@ -124,9 +163,34 @@ public class Program
         ?? typeof(Program).Assembly.GetName().Version?.ToString()
         ?? "unknown";
 
+    internal static void PrintSupportedFiles()
+    {
+        const int extWidth = 20;
+        var separator = new string('─', extWidth) + "  " + new string('─', 20);
+
+        Console.WriteLine("Supported file types:");
+        Console.WriteLine($"  {"Extension/Pattern",-20}  Handler");
+        Console.WriteLine($"  {separator}");
+        foreach (var (ext, handler) in SupportedFileTypes)
+        {
+            Console.WriteLine($"  {ext,-20}  {handler}");
+        }
+    }
+
     private static async Task<int> Run(string[] args)
     {
         var (root, _) = CreateRootCommand();
-        return await root.InvokeAsync(args);
+        var parser = new CommandLineBuilder(root)
+            .UseHelp()
+            .UseEnvironmentVariableDirective()
+            .UseParseDirective()
+            .UseSuggestDirective()
+            .RegisterWithDotnetSuggest()
+            .UseTypoCorrections()
+            .UseParseErrorReporting()
+            .UseExceptionHandler()
+            .CancelOnProcessTermination()
+            .Build();
+        return await parser.InvokeAsync(args);
     }
 }

--- a/src/CodeToNeo4j/ProgramOptions/Options.cs
+++ b/src/CodeToNeo4j/ProgramOptions/Options.cs
@@ -7,7 +7,7 @@ public sealed record Options(
     FileInfo Sln,
     string Uri,
     string User,
-    string Pass,
+    string? Pass,
     bool NoKey,
     string? DiffBase,
     int BatchSize,
@@ -16,7 +16,10 @@ public sealed record Options(
     bool SkipDependencies,
     Accessibility MinAccessibility,
     IEnumerable<string> IncludeExtensions,
-    bool PurgeData)
+    bool PurgeData,
+    bool ShowVersion,
+    bool ShowSupportedFiles,
+    bool ShowInfo)
 {
     private bool PrintMembers(System.Text.StringBuilder builder)
     {
@@ -34,6 +37,9 @@ public sealed record Options(
         builder.AppendLine($"\tMinAccessibility = {MinAccessibility}, ");
         builder.AppendLine($"\tIncludeExtensions = [ {string.Join(", ", IncludeExtensions)} ], ");
         builder.AppendLine($"\tPurgeData = {PurgeData}");
+        builder.AppendLine($"\tShowVersion = {ShowVersion}");
+        builder.AppendLine($"\tShowSupportedFiles = {ShowSupportedFiles}");
+        builder.AppendLine($"\tShowInfo = {ShowInfo}");
         return true;
     }
 

--- a/src/CodeToNeo4j/ProgramOptions/OptionsBinder.cs
+++ b/src/CodeToNeo4j/ProgramOptions/OptionsBinder.cs
@@ -21,7 +21,10 @@ public class OptionsBinder(
     Option<bool> quietOption,
     Option<bool> skipDependenciesOption,
     Option<bool> purgeDataOption,
-    Option<string[]> includeExtensionsOption) : BinderBase<Options>
+    Option<string[]> includeExtensionsOption,
+    Option<bool> showVersionOption,
+    Option<bool> showSupportedFilesOption,
+    Option<bool> showInfoOption) : BinderBase<Options>
 {
     public void AddToCommand(Command command)
     {
@@ -41,6 +44,9 @@ public class OptionsBinder(
         command.AddOption(skipDependenciesOption);
         command.AddOption(purgeDataOption);
         command.AddOption(includeExtensionsOption);
+        command.AddOption(showVersionOption);
+        command.AddOption(showSupportedFilesOption);
+        command.AddOption(showInfoOption);
 
         command.AddValidator(result => OptionsBinderValidator.Validate(
             result,
@@ -52,7 +58,11 @@ public class OptionsBinder(
             quietOption,
             purgeDataOption,
             skipDependenciesOption,
-            minAccessibilityOption));
+            minAccessibilityOption,
+            passOption,
+            showVersionOption,
+            showSupportedFilesOption,
+            showInfoOption));
     }
 
     protected override Options GetBoundValue(BindingContext bindingContext) =>
@@ -60,7 +70,7 @@ public class OptionsBinder(
             bindingContext.ParseResult.GetValueForOption(slnOption)!,
             bindingContext.ParseResult.GetValueForOption(uriOption)!,
             bindingContext.ParseResult.GetValueForOption(userOption)!,
-            bindingContext.ParseResult.GetValueForOption(passOption)!,
+            bindingContext.ParseResult.GetValueForOption(passOption),
             bindingContext.ParseResult.GetValueForOption(noKeyOption),
             bindingContext.ParseResult.GetValueForOption(diffBaseOption),
             bindingContext.ParseResult.GetValueForOption(batchSizeOption),
@@ -69,7 +79,10 @@ public class OptionsBinder(
             bindingContext.ParseResult.GetValueForOption(skipDependenciesOption),
             bindingContext.ParseResult.GetValueForOption(minAccessibilityOption),
             bindingContext.ParseResult.GetValueForOption(includeExtensionsOption)!,
-            bindingContext.ParseResult.GetValueForOption(purgeDataOption)
+            bindingContext.ParseResult.GetValueForOption(purgeDataOption),
+            bindingContext.ParseResult.GetValueForOption(showVersionOption),
+            bindingContext.ParseResult.GetValueForOption(showSupportedFilesOption),
+            bindingContext.ParseResult.GetValueForOption(showInfoOption)
         );
 
     private LogLevel ParseLogLevel(BindingContext bindingContext)

--- a/src/CodeToNeo4j/ProgramOptions/OptionsBinderValidator.cs
+++ b/src/CodeToNeo4j/ProgramOptions/OptionsBinderValidator.cs
@@ -17,11 +17,29 @@ public static class OptionsBinderValidator
         Option<bool> quietOption,
         Option<bool> purgeDataOption,
         Option<bool> skipDependenciesOption,
-        Option<Accessibility> minAccessibilityOption)
+        Option<Accessibility> minAccessibilityOption,
+        Option<string> passOption,
+        Option<bool> showVersionOption,
+        Option<bool> showSupportedFilesOption,
+        Option<bool> showInfoOption)
     {
+        var isInfo = result.GetValueForOption(showVersionOption)
+                     || result.GetValueForOption(showSupportedFilesOption)
+                     || result.GetValueForOption(showInfoOption);
+
+        if (isInfo)
+            return;
+
         var isPurge = result.GetValueForOption(purgeDataOption);
         var noKey = result.GetValueForOption(noKeyOption);
         var sln = result.GetValueForOption(slnOption);
+        var pass = result.FindResultFor(passOption);
+
+        if (pass is null)
+        {
+            result.ErrorMessage = "--password is required";
+            return;
+        }
 
         if (isPurge)
         {

--- a/tests/CodeToNeo4j.Tests/Handlers/OptionsHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/Handlers/OptionsHandlerTests.cs
@@ -149,5 +149,8 @@ public class OptionsHandlerTests
         skipDependencies,
         Microsoft.CodeAnalysis.Accessibility.Private,
         includeExtensions ?? [],
-        purgeData);
+        purgeData,
+        ShowVersion: false,
+        ShowSupportedFiles: false,
+        ShowInfo: false);
 }

--- a/tests/CodeToNeo4j.Tests/ProgramTests.cs
+++ b/tests/CodeToNeo4j.Tests/ProgramTests.cs
@@ -145,4 +145,84 @@ public class ProgramTests
         // assert
         version.ShouldNotBeNullOrWhiteSpace();
     }
+
+    // ── Info switches ────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("--supported-files")]
+    [InlineData("--info")]
+    public void GivenInfoSwitch_WhenParsingWithNoOtherArgs_ThenShouldNotHaveErrors(string infoSwitch)
+    {
+        // arrange
+        var (sut, _) = Program.CreateRootCommand();
+
+        // act
+        var result = sut.Parse(infoSwitch);
+
+        // assert
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("--supported-files")]
+    [InlineData("--info")]
+    public async Task GivenInfoSwitch_WhenInvoked_ThenExitsWithCodeZero(string infoSwitch)
+    {
+        // act
+        var exitCode = await Program.Main([infoSwitch]);
+
+        // assert
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GivenVersionRequested_WhenFormattingVersionLine_ThenContainsToolNameAndVersion()
+    {
+        // act
+        var version = Program.GetVersion();
+
+        // assert — the version line is "CodeToNeo4j {version}"
+        var line = $"CodeToNeo4j {version}";
+        line.ShouldContain("CodeToNeo4j");
+        line.ShouldContain(version);
+    }
+
+    [Fact]
+    public void GivenPrintSupportedFiles_WhenCalled_ThenAllHandlersAreListed()
+    {
+        // arrange
+        var stdout = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(stdout);
+
+        try
+        {
+            // act
+            Program.PrintSupportedFiles();
+
+            // assert
+            var output = stdout.ToString();
+            output.ShouldContain("Supported file types:");
+            foreach (var (ext, handler) in Program.SupportedFileTypes)
+            {
+                output.ShouldContain(ext);
+                output.ShouldContain(handler);
+            }
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void GivenSupportedFileTypes_WhenChecked_ThenContainsExpectedEntries()
+    {
+        Program.SupportedFileTypes.ShouldContain(e => e.Extension == ".cs" && e.HandlerName == "CSharpHandler");
+        Program.SupportedFileTypes.ShouldContain(e => e.Extension == "package.json" && e.HandlerName == "PackageJsonHandler");
+        Program.SupportedFileTypes.ShouldContain(e => e.Extension == ".csproj" && e.HandlerName == "CsprojHandler");
+        Program.SupportedFileTypes.ShouldContain(e => e.Extension.Contains(".ts") && e.HandlerName == "TypeScriptHandler");
+    }
 }

--- a/tests/CodeToNeo4j.Tests/Validation/OptionsBinderValidatorTests.cs
+++ b/tests/CodeToNeo4j.Tests/Validation/OptionsBinderValidatorTests.cs
@@ -19,6 +19,10 @@ public class OptionsBinderValidatorTests
     private readonly Option<bool> _purgeDataOption = new("--purge-data");
     private readonly Option<bool> _skipDependenciesOption = new("--skip-dependencies");
     private readonly Option<Accessibility> _minAccessibilityOption;
+    private readonly Option<string> _passOption = new("--password");
+    private readonly Option<bool> _showVersionOption = new("--version");
+    private readonly Option<bool> _showSupportedFilesOption = new("--supported-files");
+    private readonly Option<bool> _showInfoOption = new("--info");
 
     public OptionsBinderValidatorTests()
     {
@@ -38,7 +42,11 @@ public class OptionsBinderValidatorTests
             _quietOption,
             _purgeDataOption,
             _skipDependenciesOption,
-            _minAccessibilityOption
+            _minAccessibilityOption,
+            _passOption,
+            _showVersionOption,
+            _showSupportedFilesOption,
+            _showInfoOption
         };
 
         return root.Parse(args).CommandResult;
@@ -56,14 +64,18 @@ public class OptionsBinderValidatorTests
             _quietOption,
             _purgeDataOption,
             _skipDependenciesOption,
-            _minAccessibilityOption);
+            _minAccessibilityOption,
+            _passOption,
+            _showVersionOption,
+            _showSupportedFilesOption,
+            _showInfoOption);
     }
 
     [Fact]
     public void GivenMultipleLogOptions_WhenValidating_ThenShouldHaveErrorMessage()
     {
         // arrange
-        var result = GetCommandResult("--sln", "test.sln", "--debug", "--quiet");
+        var result = GetCommandResult("--sln", "test.sln", "--password", "pass", "--debug", "--quiet");
 
         // act
         Validate(result);
@@ -76,7 +88,7 @@ public class OptionsBinderValidatorTests
     public void GivenPurgeWithSkipDependencies_WhenValidating_ThenShouldNotHaveErrorMessage()
     {
         // arrange
-        var result = GetCommandResult("--sln", "test.sln", "--purge-data", "--skip-dependencies");
+        var result = GetCommandResult("--sln", "test.sln", "--password", "pass", "--purge-data", "--skip-dependencies");
 
         // act
         Validate(result);
@@ -89,7 +101,7 @@ public class OptionsBinderValidatorTests
     public void GivenPurgeWithMinAccessibility_WhenValidating_ThenShouldHaveErrorMessage()
     {
         // arrange
-        var result = GetCommandResult("--sln", "test.sln", "--purge-data", "--min-accessibility", "Public");
+        var result = GetCommandResult("--sln", "test.sln", "--password", "pass", "--purge-data", "--min-accessibility", "Public");
 
         // act
         Validate(result);
@@ -102,7 +114,7 @@ public class OptionsBinderValidatorTests
     public void GivenValidOptions_WhenValidating_ThenShouldNotHaveErrorMessage()
     {
         // arrange
-        var result = GetCommandResult("--sln", "test.sln", "--debug", "--purge-data");
+        var result = GetCommandResult("--sln", "test.sln", "--password", "pass", "--debug", "--purge-data");
 
         // act
         Validate(result);
@@ -115,7 +127,7 @@ public class OptionsBinderValidatorTests
     public void GivenNoSln_WhenPurgeDataAndNoKey_ThenShouldNotHaveErrorMessage()
     {
         // arrange
-        var result = GetCommandResult("--purge-data", "--no-key");
+        var result = GetCommandResult("--purge-data", "--no-key", "--password", "pass");
 
         // act
         Validate(result);
@@ -128,7 +140,7 @@ public class OptionsBinderValidatorTests
     public void GivenNoSln_WhenPurgeDataWithoutNoKey_ThenShouldHaveErrorMessage()
     {
         // arrange
-        var result = GetCommandResult("--purge-data");
+        var result = GetCommandResult("--purge-data", "--password", "pass");
 
         // act
         Validate(result);
@@ -141,12 +153,41 @@ public class OptionsBinderValidatorTests
     public void GivenNoSln_WhenNoPurgeData_ThenShouldHaveErrorMessage()
     {
         // arrange
-        var result = GetCommandResult("--debug");
+        var result = GetCommandResult("--debug", "--password", "pass");
 
         // act
         Validate(result);
 
         // assert
         result.ErrorMessage.ShouldBe("--sln is required");
+    }
+
+    [Fact]
+    public void GivenNoPassword_WhenNoPurgeData_ThenShouldHaveErrorMessage()
+    {
+        // arrange
+        var result = GetCommandResult("--sln", "test.sln");
+
+        // act
+        Validate(result);
+
+        // assert
+        result.ErrorMessage.ShouldBe("--password is required");
+    }
+
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("--supported-files")]
+    [InlineData("--info")]
+    public void GivenInfoSwitch_WhenNoOtherRequiredOptions_ThenShouldNotHaveErrorMessage(string infoSwitch)
+    {
+        // arrange
+        var result = GetCommandResult(infoSwitch);
+
+        // act
+        Validate(result);
+
+        // assert
+        result.ErrorMessage.ShouldBeNull();
     }
 }


### PR DESCRIPTION
## Summary

Add three new informational CLI switches: `--version`, `--supported-files`, and `--info`. All three short-circuit before any Neo4j connection is attempted. Uses `CommandLineBuilder` without `UseVersionOption()` to avoid conflict with System.CommandLine's built-in `--version` middleware.

## Issue

Resolves #56

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change