### PR TITLE
Performance: handler lookup, regex, git metadata, lazy enum

### DIFF
--- a/src/CodeToNeo4j/FileHandlers/HtmlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/HtmlHandler.cs
@@ -67,7 +67,7 @@ public partial class HtmlHandler(IFileSystem fileSystem, ITextSymbolMapper textS
         if (Accessibility.Public < minAccessibility) return;
 
         // Extract IDs
-        var idRegex = new Regex(@"id=['""](.*?)['""]", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+        var idRegex = IdRegex();
         foreach (Match match in idRegex.Matches(content))
         {
             var id = match.Groups[1].Value;
@@ -89,6 +89,9 @@ public partial class HtmlHandler(IFileSystem fileSystem, ITextSymbolMapper textS
             relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: key, RelType: "CONTAINS"));
         }
     }
+
+    [GeneratedRegex(@"id=['""](.*?)['""]", RegexOptions.IgnoreCase | RegexOptions.Multiline, "en-CA")]
+    private static partial Regex IdRegex();
 
     [GeneratedRegex(@"<script\s+.*?src=['""](.*?)['""]", RegexOptions.IgnoreCase | RegexOptions.Multiline, "en-CA")]
     private static partial Regex ScriptRegex();

--- a/src/CodeToNeo4j/FileHandlers/PackageJsonHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/PackageJsonHandler.cs
@@ -155,7 +155,7 @@ public class PackageJsonHandler(IFileSystem fileSystem, ITextSymbolMapper textSy
         {
             var pnpmEntryName = name.Replace("/", "+", StringComparison.Ordinal);
             var prefix = $"{pnpmEntryName}@";
-            var match = _fileSystem.Directory.GetDirectories(pnpmStoreDir)
+            var match = _fileSystem.Directory.EnumerateDirectories(pnpmStoreDir)
                 .FirstOrDefault(d => _fileSystem.Path.GetFileName(d).StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
 
             if (match is not null)

--- a/src/CodeToNeo4j/Solution/SolutionProcessor.cs
+++ b/src/CodeToNeo4j/Solution/SolutionProcessor.cs
@@ -22,6 +22,7 @@ public class SolutionProcessor(
     ISolutionFileDiscoveryService discoveryService,
     ILogger<SolutionProcessor> logger) : ISolutionProcessor
 {
+    private readonly HandlerLookup _handlerLookup = new(handlers);
     public async Task ProcessSolution(FileInfo sln, string? repoKey, string? diffBase, string databaseName, int batchSize, bool skipDependencies, Accessibility minAccessibility, IEnumerable<string> includeExtensions)
     {
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -34,6 +35,9 @@ public class SolutionProcessor(
         logger.LogInformation("Opening solution...");
         var solution = await workspace.OpenSolutionAsync(sln.FullName).ConfigureAwait(false);
         logger.LogInformation("Solution opened successfully.");
+
+        // Start git metadata loading in background so it overlaps with dependency ingestion and diff computation
+        var metadataTask = versionControlService.LoadMetadata(solutionRoot, extensionsToInclude);
 
         if (!skipDependencies)
         {
@@ -66,7 +70,8 @@ public class SolutionProcessor(
 
         logger.LogInformation("Processing {Count} files in solution: {SlnName}...", totalFiles, sln.Name);
 
-        await versionControlService.LoadMetadata(solutionRoot, extensionsToInclude).ConfigureAwait(false);
+        // Ensure git metadata is fully loaded before processing files
+        await metadataTask.ConfigureAwait(false);
         var channel = Channel.CreateBounded<ProcessResult>(new BoundedChannelOptions(100)
         {
             FullMode = BoundedChannelFullMode.Wait,
@@ -250,7 +255,7 @@ public class SolutionProcessor(
             }
         }
 
-        var handler = handlers.FirstOrDefault(h => h.CanHandle(filePath));
+        var handler = _handlerLookup.GetHandler(filePath);
         FileResult? fileResult = null;
         if (handler != null)
         {
@@ -272,4 +277,55 @@ public class SolutionProcessor(
         List<Relationship> Relationships,
         List<UrlNode> UrlNodes,
         string RelativePath);
+
+    internal sealed class HandlerLookup
+    {
+        private readonly Dictionary<string, IDocumentHandler> _byFileName = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, IDocumentHandler> _byExtension = new(StringComparer.OrdinalIgnoreCase);
+
+        public HandlerLookup(IEnumerable<IDocumentHandler> handlers)
+        {
+            foreach (var handler in handlers)
+            {
+                var ext = handler.FileExtension;
+
+                // Handlers whose FileExtension is a full filename (e.g. "package.json")
+                // are indexed by filename for O(1) lookup.
+                if (!ext.StartsWith('.'))
+                {
+                    _byFileName.TryAdd(ext, handler);
+                    continue;
+                }
+
+                _byExtension.TryAdd(ext, handler);
+            }
+        }
+
+        public IDocumentHandler? GetHandler(string filePath)
+        {
+            // O(1) filename lookup (e.g. package.json)
+            var fileName = Path.GetFileName(filePath);
+            if (_byFileName.TryGetValue(fileName, out var byName))
+                return byName;
+
+            // O(1) extension lookup (e.g. .cs, .html)
+            var ext = Path.GetExtension(filePath);
+            if (!string.IsNullOrEmpty(ext) && _byExtension.TryGetValue(ext, out var byExt))
+            {
+                // Verify via CanHandle for handlers that match multiple extensions (e.g. .ts/.tsx)
+                if (byExt.CanHandle(filePath))
+                    return byExt;
+            }
+
+            // Linear fallback for files that didn't match by extension or filename
+            // (e.g. .tsx files matched to the .ts handler)
+            foreach (var handler in _byExtension.Values)
+            {
+                if (handler.CanHandle(filePath))
+                    return handler;
+            }
+
+            return null;
+        }
+    }
 }

--- a/tests/CodeToNeo4j.Tests/Solution/HandlerLookupTests.cs
+++ b/tests/CodeToNeo4j.Tests/Solution/HandlerLookupTests.cs
@@ -1,0 +1,127 @@
+using CodeToNeo4j.FileHandlers;
+using CodeToNeo4j.Solution;
+using FakeItEasy;
+using Shouldly;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.Solution;
+
+public class HandlerLookupTests
+{
+    [Theory]
+    [InlineData("/repo/src/Program.cs", ".cs")]
+    [InlineData("/repo/src/Index.html", ".html")]
+    [InlineData("/repo/src/style.css", ".css")]
+    [InlineData("/repo/src/App.razor", ".razor")]
+    [InlineData("/repo/src/data.xml", ".xml")]
+    [InlineData("/repo/src/App.xaml", ".xaml")]
+    [InlineData("/repo/src/project.csproj", ".csproj")]
+    [InlineData("/repo/src/app.js", ".js")]
+    public void GivenExtensionHandler_WhenGetHandlerCalled_ThenReturnsDictionaryMatch(string filePath, string extension)
+    {
+        // Arrange
+        var handler = CreateExtensionHandler(extension);
+        var sut = new SolutionProcessor.HandlerLookup([handler]);
+
+        // Act
+        var result = sut.GetHandler(filePath);
+
+        // Assert
+        result.ShouldBe(handler);
+    }
+
+    [Theory]
+    [InlineData("/repo/src/app.ts")]
+    [InlineData("/repo/src/Component.tsx")]
+    public void GivenTypeScriptHandler_WhenGetHandlerCalled_ThenMatchesTsAndTsx(string filePath)
+    {
+        // Arrange
+        var tsHandler = CreateExtensionHandler(".ts", path =>
+            path.EndsWith(".ts", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase));
+        var sut = new SolutionProcessor.HandlerLookup([tsHandler]);
+
+        // Act
+        var result = sut.GetHandler(filePath);
+
+        // Assert
+        result.ShouldBe(tsHandler);
+    }
+
+    [Fact]
+    public void GivenPackageJsonAndJsonHandlers_WhenGetHandlerCalledWithPackageJson_ThenReturnsPackageJsonHandler()
+    {
+        // Arrange
+        var pkgHandler = CreateFileNameHandler("package.json");
+        var jsonHandler = CreateExtensionHandler(".json");
+        var sut = new SolutionProcessor.HandlerLookup([pkgHandler, jsonHandler]);
+
+        // Act
+        var result = sut.GetHandler("/repo/package.json");
+
+        // Assert
+        result.ShouldBe(pkgHandler);
+    }
+
+    [Fact]
+    public void GivenPackageJsonAndJsonHandlers_WhenGetHandlerCalledWithRegularJson_ThenReturnsJsonHandler()
+    {
+        // Arrange
+        var pkgHandler = CreateFileNameHandler("package.json");
+        var jsonHandler = CreateExtensionHandler(".json");
+        var sut = new SolutionProcessor.HandlerLookup([pkgHandler, jsonHandler]);
+
+        // Act
+        var result = sut.GetHandler("/repo/appsettings.json");
+
+        // Assert
+        result.ShouldBe(jsonHandler);
+    }
+
+    [Fact]
+    public void GivenNoMatchingHandler_WhenGetHandlerCalled_ThenReturnsNull()
+    {
+        // Arrange
+        var handler = CreateExtensionHandler(".cs");
+        var sut = new SolutionProcessor.HandlerLookup([handler]);
+
+        // Act
+        var result = sut.GetHandler("/repo/file.unknown");
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenCaseInsensitiveExtension_WhenGetHandlerCalled_ThenReturnsMatch()
+    {
+        // Arrange
+        var handler = CreateExtensionHandler(".cs");
+        var sut = new SolutionProcessor.HandlerLookup([handler]);
+
+        // Act
+        var result = sut.GetHandler("/repo/Program.CS");
+
+        // Assert
+        result.ShouldBe(handler);
+    }
+
+    private static IDocumentHandler CreateExtensionHandler(string extension, Func<string, bool>? canHandle = null)
+    {
+        var handler = A.Fake<IDocumentHandler>();
+        A.CallTo(() => handler.FileExtension).Returns(extension);
+        A.CallTo(() => handler.CanHandle(A<string>._))
+            .ReturnsLazily((string path) => canHandle?.Invoke(path)
+                                            ?? path.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
+        return handler;
+    }
+
+    private static IDocumentHandler CreateFileNameHandler(string fileName)
+    {
+        var handler = A.Fake<IDocumentHandler>();
+        A.CallTo(() => handler.FileExtension).Returns(fileName);
+        A.CallTo(() => handler.CanHandle(A<string>._))
+            .ReturnsLazily((string path) => Path.GetFileName(path).Equals(fileName, StringComparison.OrdinalIgnoreCase));
+        return handler;
+    }
+}


### PR DESCRIPTION
## Summary

- **Dictionary-based handler dispatch**: Replace O(n) `FirstOrDefault` handler lookup with O(1) dictionary keyed by file extension/filename, with linear fallback only for multi-extension handlers (e.g. `.ts`/`.tsx`)
- **Source-generated regex**: Convert the runtime `new Regex(...)` in `HtmlHandler.ExtractIdsAndClasses` to `[GeneratedRegex]` for faster startup and AOT compatibility
- **Background git metadata loading**: Start `LoadMetadata` immediately after opening the solution so it overlaps with dependency ingestion and diff computation instead of blocking startup
- **Lazy directory enumeration**: Replace `Directory.GetDirectories()` with `Directory.EnumerateDirectories()` in `PackageJsonHandler.ResolvePackageMetadataPath` to avoid materializing the full array

## Issue

Resolves #59

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change