### PR TITLE
Extract shared utilities to eliminate DRY violations across handlers

### DIFF
--- a/src/CodeToNeo4j/FileHandlers/CsprojHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/CsprojHandler.cs
@@ -3,10 +3,11 @@ using System.Xml;
 using System.Xml.Linq;
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 namespace CodeToNeo4j.FileHandlers;
 
-public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper)
+public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper, ILogger<CsprojHandler> logger)
     : PackageDependencyHandlerBase(fileSystem, textSymbolMapper)
 {
     public override string FileExtension => ".csproj";
@@ -34,15 +35,16 @@ public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolM
                 await ProcessProject(xdoc.Root, fileKey, relativePath, fileNamespace ?? string.Empty, symbolBuffer, relBuffer, urlNodes, minAccessibility).ConfigureAwait(false);
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Fail gracefully
+            _logger.LogWarning(ex, "Failed to parse .csproj file: {FilePath}", filePath);
         }
 
         return new FileResult(fileNamespace, fileKey, urlNodes.Count > 0 ? urlNodes : null);
     }
 
     private readonly IFileSystem _fileSystem = fileSystem;
+    private readonly ILogger<CsprojHandler> _logger = logger;
 
     private async Task ProcessProject(XElement project, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, List<UrlNode> urlNodes, Accessibility minAccessibility)
     {
@@ -168,8 +170,9 @@ public class CsprojHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolM
 
             return (projectUrl, repositoryUrl);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Failed to read .nuspec metadata for package: {PackageName}", name);
             return (null, null);
         }
     }

--- a/src/CodeToNeo4j/FileHandlers/CssHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/CssHandler.cs
@@ -30,7 +30,7 @@ public partial class CssHandler(IFileSystem fileSystem, ITextSymbolMapper textSy
 
     private void ExtractSelectors(string content, string fileKey, string relativePath, string fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
-        if (Accessibility.Public < minAccessibility) return;
+        if (!IsPublicAccessible(minAccessibility)) return;
 
         // Basic regex to find CSS selectors
         var matches = Regex().Matches(content);
@@ -40,7 +40,7 @@ public partial class CssHandler(IFileSystem fileSystem, ITextSymbolMapper textSy
             var selector = match.Groups[1].Value.Trim();
             if (string.IsNullOrEmpty(selector) || selector.StartsWith("@")) continue;
 
-            var startLine = content[..match.Index].Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             var key = textSymbolMapper.BuildKey(fileKey, "CssSelector", selector, startLine);
 
             var record = textSymbolMapper.CreateSymbol(

--- a/src/CodeToNeo4j/FileHandlers/DocumentHandlerBase.cs
+++ b/src/CodeToNeo4j/FileHandlers/DocumentHandlerBase.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using System.Linq;
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
 
@@ -42,6 +43,12 @@ public abstract class DocumentHandlerBase(IFileSystem fileSystem) : IDocumentHan
             ? document.GetTextAsync()
                 .ContinueWith(x => x.Result.ToString())
             : fileSystem.File.ReadAllTextAsync(filePath);
+
+    protected static int GetLineNumber(string content, int index)
+        => content[..index].Count(c => c == '\n') + 1;
+
+    protected static bool IsPublicAccessible(Accessibility minAccessibility)
+        => Accessibility.Public >= minAccessibility;
 
     private int _numberOfFilesHandled;
 }

--- a/src/CodeToNeo4j/FileHandlers/HtmlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/HtmlHandler.cs
@@ -34,7 +34,7 @@ public partial class HtmlHandler(IFileSystem fileSystem, ITextSymbolMapper textS
 
     private void ExtractScriptReferences(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
-        if (Accessibility.Public < minAccessibility)
+        if (!IsPublicAccessible(minAccessibility))
         {
             return;
         }
@@ -43,7 +43,7 @@ public partial class HtmlHandler(IFileSystem fileSystem, ITextSymbolMapper textS
         foreach (Match match in scriptRegex.Matches(content))
         {
             var src = match.Groups[1].Value;
-            var startLine = content.Substring(0, match.Index).Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             var key = textSymbolMapper.BuildKey(fileKey, "ScriptRef", src, startLine);
 
             var record = textSymbolMapper.CreateSymbol(
@@ -64,14 +64,14 @@ public partial class HtmlHandler(IFileSystem fileSystem, ITextSymbolMapper textS
 
     private void ExtractIdsAndClasses(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
-        if (Accessibility.Public < minAccessibility) return;
+        if (!IsPublicAccessible(minAccessibility)) return;
 
         // Extract IDs
         var idRegex = IdRegex();
         foreach (Match match in idRegex.Matches(content))
         {
             var id = match.Groups[1].Value;
-            var startLine = content.Substring(0, match.Index).Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             var key = textSymbolMapper.BuildKey(fileKey, "ElementId", id, startLine);
 
             var record = textSymbolMapper.CreateSymbol(

--- a/src/CodeToNeo4j/FileHandlers/JsHandlerBase.cs
+++ b/src/CodeToNeo4j/FileHandlers/JsHandlerBase.cs
@@ -53,7 +53,7 @@ public abstract partial class JsHandlerBase(IFileSystem fileSystem, ITextSymbolM
 
     private void ExtractFunctions(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
-        if (Accessibility.Public < minAccessibility)
+        if (!IsPublicAccessible(minAccessibility))
             return;
 
         var functionRegex = FunctionRegex();
@@ -68,7 +68,7 @@ public abstract partial class JsHandlerBase(IFileSystem fileSystem, ITextSymbolM
 
             if (string.IsNullOrEmpty(name)) continue;
 
-            var startLine = content[..match.Index].Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             var key = TextSymbolMapper.BuildKey(fileKey, "Function", name, startLine);
 
             var record = TextSymbolMapper.CreateSymbol(
@@ -95,19 +95,19 @@ public abstract partial class JsHandlerBase(IFileSystem fileSystem, ITextSymbolM
 
     private void ExtractImportsExports(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
-        if (Accessibility.Public < minAccessibility) return;
+        if (!IsPublicAccessible(minAccessibility)) return;
 
         foreach (Match match in ImportRegex().Matches(content))
         {
             var module = match.Groups[1].Value;
-            var startLine = content[..match.Index].Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             AddModuleReference(module, fileKey, relativePath, fileNamespace, startLine, symbolBuffer, relBuffer);
         }
 
         foreach (Match match in RequireRegex().Matches(content))
         {
             var module = match.Groups[1].Value;
-            var startLine = content[..match.Index].Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             AddModuleReference(module, fileKey, relativePath, fileNamespace, startLine, symbolBuffer, relBuffer);
         }
     }

--- a/src/CodeToNeo4j/FileHandlers/PackageJsonHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/PackageJsonHandler.cs
@@ -136,9 +136,9 @@ public class PackageJsonHandler(IFileSystem fileSystem, ITextSymbolMapper textSy
                     urlNodes.Add(new UrlNode(depKey, $"url:{repoUrl}", repoUrl));
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Fail gracefully
+            logger.LogWarning(ex, "Failed to read npm package metadata for: {PackageName}", name);
         }
     }
 

--- a/src/CodeToNeo4j/FileHandlers/RazorHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/RazorHandler.cs
@@ -85,7 +85,7 @@ public partial class RazorHandler(
 
     private void ExtractDirectives(string content, string fileKey, string relativePath, string? fileNamespace, ICollection<Symbol> symbolBuffer, ICollection<Relationship> relBuffer, Accessibility minAccessibility)
     {
-        if (Accessibility.Public < minAccessibility)
+        if (!IsPublicAccessible(minAccessibility))
         {
             return;
         }
@@ -102,7 +102,7 @@ public partial class RazorHandler(
 
             var name = match.Groups[1].Value.Trim();
             var key = textSymbolMapper.BuildKey(fileKey, kind, name);
-            var startLine = content[..match.Index].Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
 
             var record = textSymbolMapper.CreateSymbol(
                 key: key,

--- a/src/CodeToNeo4j/FileHandlers/TypeScriptHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/TypeScriptHandler.cs
@@ -23,7 +23,7 @@ public partial class TypeScriptHandler(IFileSystem fileSystem, ITextSymbolMapper
         ICollection<Relationship> relBuffer,
         Accessibility minAccessibility)
     {
-        if (Accessibility.Public < minAccessibility) return;
+        if (!IsPublicAccessible(minAccessibility)) return;
 
         ExtractInterfaces(content, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer);
         ExtractTypeAliases(content, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer);
@@ -35,7 +35,7 @@ public partial class TypeScriptHandler(IFileSystem fileSystem, ITextSymbolMapper
         foreach (Match match in InterfaceRegex().Matches(content))
         {
             var name = match.Groups[1].Value;
-            var startLine = content[..match.Index].Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             var key = TextSymbolMapper.BuildKey(fileKey, "Interface", name, startLine);
 
             symbolBuffer.Add(TextSymbolMapper.CreateSymbol(
@@ -58,7 +58,7 @@ public partial class TypeScriptHandler(IFileSystem fileSystem, ITextSymbolMapper
         foreach (Match match in TypeAliasRegex().Matches(content))
         {
             var name = match.Groups[1].Value;
-            var startLine = content[..match.Index].Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             var key = TextSymbolMapper.BuildKey(fileKey, "TypeAlias", name, startLine);
 
             symbolBuffer.Add(TextSymbolMapper.CreateSymbol(
@@ -81,7 +81,7 @@ public partial class TypeScriptHandler(IFileSystem fileSystem, ITextSymbolMapper
         foreach (Match match in EnumRegex().Matches(content))
         {
             var name = match.Groups[1].Value;
-            var startLine = content[..match.Index].Count(c => c == '\n') + 1;
+            var startLine = GetLineNumber(content, match.Index);
             var key = TextSymbolMapper.BuildKey(fileKey, "Enum", name, startLine);
 
             symbolBuffer.Add(TextSymbolMapper.CreateSymbol(

--- a/src/CodeToNeo4j/FileHandlers/XamlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/XamlHandler.cs
@@ -3,13 +3,15 @@ using System.Xml.Linq;
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
 
 namespace CodeToNeo4j.FileHandlers;
 
 public class XamlHandler(
     IRoslynSymbolProcessor symbolProcessor,
     IFileSystem fileSystem,
-    ITextSymbolMapper textSymbolMapper)
+    ITextSymbolMapper textSymbolMapper,
+    ILogger<XamlHandler> logger)
     : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".xaml";
@@ -45,9 +47,9 @@ public class XamlHandler(
                 ProcessElement(xdoc.Root, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Ignore XML parse errors
+            _logger.LogWarning(ex, "Failed to parse XAML file: {FilePath}", filePath);
         }
 
         // Use Roslyn to extract members from generated code
@@ -171,6 +173,8 @@ public class XamlHandler(
                attrName.EndsWith("Released") ||
                attrName == "Command";
     }
+
+    private readonly ILogger<XamlHandler> _logger = logger;
 
     private static readonly string[] XamlNamespaces =
     [

--- a/src/CodeToNeo4j/FileHandlers/XmlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/XmlHandler.cs
@@ -2,10 +2,11 @@ using System.IO.Abstractions;
 using System.Xml.Linq;
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 namespace CodeToNeo4j.FileHandlers;
 
-public class XmlHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper) : DocumentHandlerBase(fileSystem)
+public class XmlHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapper, ILogger<XmlHandler> logger) : DocumentHandlerBase(fileSystem)
 {
     public override string FileExtension => ".xml";
 
@@ -31,9 +32,9 @@ public class XmlHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapp
                 ProcessElement(xdoc.Root, fileKey, relativePath, fileNamespace ?? string.Empty, symbolBuffer, relBuffer, minAccessibility);
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Fail gracefully for malformed XML
+            _logger.LogWarning(ex, "Failed to parse XML file: {FilePath}", filePath);
         }
 
         return new FileResult(fileNamespace, fileKey);
@@ -68,4 +69,6 @@ public class XmlHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapp
             ProcessElement(child, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);
         }
     }
+
+    private readonly ILogger<XmlHandler> _logger = logger;
 }

--- a/tests/CodeToNeo4j.Tests/FileHandlers/CsprojHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/CsprojHandlerTests.cs
@@ -2,6 +2,7 @@ using System.IO.Abstractions.TestingHelpers;
 using CodeToNeo4j.FileHandlers;
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using Xunit;
 
@@ -14,7 +15,7 @@ public class CsprojHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper());
+        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper(), NullLogger<CsprojHandler>.Instance);
 
         var content = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -70,7 +71,7 @@ public class CsprojHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper());
+        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper(), NullLogger<CsprojHandler>.Instance);
 
         const string content = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <ItemGroup>
@@ -126,7 +127,7 @@ public class CsprojHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper());
+        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper(), NullLogger<CsprojHandler>.Instance);
 
         const string content = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <ItemGroup>
@@ -168,7 +169,7 @@ public class CsprojHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper());
+        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper(), NullLogger<CsprojHandler>.Instance);
 
         const string content = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <ItemGroup>
@@ -210,7 +211,7 @@ public class CsprojHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper());
+        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper(), NullLogger<CsprojHandler>.Instance);
 
         const string content = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <ItemGroup>
@@ -241,7 +242,7 @@ public class CsprojHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper());
+        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper(), NullLogger<CsprojHandler>.Instance);
 
         const string content = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <ItemGroup>
@@ -272,7 +273,7 @@ public class CsprojHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper());
+        var sut = new CsprojHandler(fileSystem, new TextSymbolMapper(), NullLogger<CsprojHandler>.Instance);
 
         const string content = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <ItemGroup>

--- a/tests/CodeToNeo4j.Tests/FileHandlers/DocumentHandlerBaseTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/DocumentHandlerBaseTests.cs
@@ -1,0 +1,49 @@
+using System.IO.Abstractions.TestingHelpers;
+using CodeToNeo4j.FileHandlers;
+using CodeToNeo4j.Graph;
+using Microsoft.CodeAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.FileHandlers;
+
+public class DocumentHandlerBaseTests
+{
+    private class TestHandler(MockFileSystem fs) : DocumentHandlerBase(fs)
+    {
+        public override string FileExtension => ".test";
+
+        protected override Task<FileResult> HandleFile(
+            TextDocument? document,
+            Compilation? compilation,
+            string? repoKey,
+            string fileKey,
+            string filePath,
+            string relativePath,
+            ICollection<Symbol> symbolBuffer,
+            ICollection<Relationship> relBuffer,
+            Accessibility minAccessibility)
+            => Task.FromResult(new FileResult(null, fileKey));
+
+        public static int TestGetLineNumber(string content, int index) => GetLineNumber(content, index);
+        public static bool TestIsPublicAccessible(Accessibility minAccessibility) => IsPublicAccessible(minAccessibility);
+    }
+
+    [Theory]
+    [InlineData("hello\nworld", 0, 1)]
+    [InlineData("hello\nworld", 6, 2)]
+    [InlineData("line1\nline2\nline3", 12, 3)]
+    public void GivenContent_WhenGetLineNumberCalled_ThenReturnsCorrectLine(string content, int index, int expected)
+    {
+        TestHandler.TestGetLineNumber(content, index).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(Accessibility.Private, true)]
+    [InlineData(Accessibility.Internal, true)]
+    [InlineData(Accessibility.Public, true)]
+    public void GivenAccessibility_WhenIsPublicAccessibleCalled_ThenReturnsExpected(Accessibility minAccessibility, bool expected)
+    {
+        TestHandler.TestIsPublicAccessible(minAccessibility).ShouldBe(expected);
+    }
+}

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlHandlerTests.cs
@@ -2,6 +2,7 @@ using System.IO.Abstractions.TestingHelpers;
 using CodeToNeo4j.FileHandlers;
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using Xunit;
 
@@ -17,7 +18,7 @@ public class XamlHandlerTests
         var symbolMapper = new SymbolMapper();
         var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
-        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper(), NullLogger<XamlHandler>.Instance);
         var content = @"
 <Window x:Class=""MyApp.MainWindow""
         xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlNamespaceTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlNamespaceTests.cs
@@ -2,6 +2,7 @@ using System.IO.Abstractions.TestingHelpers;
 using CodeToNeo4j.FileHandlers;
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using Xunit;
 
@@ -19,7 +20,7 @@ public class XamlNamespaceTests
         var symbolMapper = new SymbolMapper();
         var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
-        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper(), NullLogger<XamlHandler>.Instance);
         var content = $@"
 <Window x:Class=""MyApp.MainWindow""
         xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
@@ -58,7 +59,7 @@ public class XamlNamespaceTests
         var symbolMapper = new SymbolMapper();
         var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
-        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper(), NullLogger<XamlHandler>.Instance);
         var content = @"
 <ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
              xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
@@ -96,7 +97,7 @@ public class XamlNamespaceTests
         var symbolMapper = new SymbolMapper();
         var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
-        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper(), NullLogger<XamlHandler>.Instance);
         var content = @"
 <ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
              xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
@@ -134,7 +135,7 @@ public class XamlNamespaceTests
         var symbolMapper = new SymbolMapper();
         var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
-        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper(), NullLogger<XamlHandler>.Instance);
         var content = @"
 <Window xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"">
     <Button Name=""UnprefixedButton"" />

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlRoslynTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlRoslynTests.cs
@@ -3,6 +3,7 @@ using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using System.IO.Abstractions.TestingHelpers;
 using Xunit;
@@ -19,7 +20,7 @@ public class XamlRoslynTests
         var symbolMapper = new SymbolMapper();
         var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
         var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
-        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
+        var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper(), NullLogger<XamlHandler>.Instance);
         
         var xamlFilePath = "MainWindow.xaml";
         var xamlContent = @"<Window x:Class=""MyApp.MainWindow""

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XmlHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XmlHandlerTests.cs
@@ -2,6 +2,7 @@ using System.IO.Abstractions.TestingHelpers;
 using CodeToNeo4j.FileHandlers;
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using Xunit;
 
@@ -14,7 +15,7 @@ public class XmlHandlerTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var sut = new XmlHandler(fileSystem, new TextSymbolMapper());
+        var sut = new XmlHandler(fileSystem, new TextSymbolMapper(), NullLogger<XmlHandler>.Instance);
         var content = @"<root><child>value</child></root>";
         var filePath = "test.xml";
         fileSystem.AddFile(filePath, new MockFileData(content));


### PR DESCRIPTION
## Summary

- Added `GetLineNumber` and `IsPublicAccessible` protected static helpers to `DocumentHandlerBase`, replacing duplicated inline expressions across 6+ handlers
- Converted `HtmlHandler`'s inline `new Regex(...)` to a `[GeneratedRegex]` source-generated method
- Added `ILogger<T>` to `XamlHandler`, `CsprojHandler`, and `XmlHandler`; replaced silent `catch (Exception)` swallows with `LogWarning` calls (consistent with `JsonHandler`/`PackageJsonHandler`)
- Updated all affected handler tests to pass `NullLogger<T>.Instance`; added `DocumentHandlerBaseTests` with `[Theory]` coverage for both new utilities

## Issue

Resolves #57

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change