### PR TITLE
Refactor large classes to follow SRP

### DIFF
--- a/src/CodeToNeo4j/ContainerModule.cs
+++ b/src/CodeToNeo4j/ContainerModule.cs
@@ -43,12 +43,16 @@ public static class ContainerModule
         services.AddSingleton<IFileSystem, System.IO.Abstractions.FileSystem>();
         services.AddSingleton<ICypherService, CypherService>();
         services.AddSingleton<IFileService, FileService>();
+        services.AddSingleton<IGitLogParser, GitLogParser>();
+        services.AddSingleton<IGitMetadataCache, GitMetadataCache>();
         services.AddSingleton<IVersionControlService, GitService>();
         services.AddSingleton<ISymbolMapper, SymbolMapper>();
         services.AddSingleton<ITextSymbolMapper, TextSymbolMapper>();
+        services.AddSingleton<IMemberDependencyExtractor, MemberDependencyExtractor>();
         services.AddSingleton<IDependencyIngestor, DependencyIngestor>();
         services.AddSingleton<ISolutionFileDiscoveryService, SolutionFileDiscoveryService>();
         services.AddSingleton<IRoslynSymbolProcessor, RoslynSymbolProcessor>();
+        services.AddSingleton<ICommitIngestionService, CommitIngestionService>();
 
         services.AddSingleton<IDocumentHandler, CSharpHandler>();
         services.AddSingleton<IDocumentHandler, RazorHandler>();
@@ -69,6 +73,8 @@ public static class ContainerModule
         services.AddTransient<IOptionsHandler, SolutionProcessingHandler>();
 
         services.AddSingleton<IDriver>(_ => GraphDatabase.Driver(new Uri(neo4jUri), AuthTokens.Basic(user, pass)));
+        services.AddSingleton<INeo4jSchemaService, Neo4jSchemaService>();
+        services.AddSingleton<INeo4jFlushService, Neo4jFlushService>();
         services.AddSingleton<IGraphService, Neo4jService>();
 
         services.AddSingleton<ISolutionProcessor, SolutionProcessor>();

--- a/src/CodeToNeo4j/FileHandlers/AccessibilityFilter.cs
+++ b/src/CodeToNeo4j/FileHandlers/AccessibilityFilter.cs
@@ -1,0 +1,20 @@
+using Microsoft.CodeAnalysis;
+
+namespace CodeToNeo4j.FileHandlers;
+
+internal static class AccessibilityFilter
+{
+    internal static bool IsAccessibilityBelowMinimum(ISymbol symbol, Accessibility minAccessibility) =>
+        symbol.DeclaredAccessibility < minAccessibility
+        && symbol.DeclaredAccessibility != Accessibility.NotApplicable
+        && !IsExplicitInterfaceImplementation(symbol);
+
+    internal static bool IsExplicitInterfaceImplementation(ISymbol symbol) =>
+        symbol switch
+        {
+            IMethodSymbol method => method.ExplicitInterfaceImplementations.Any(),
+            IPropertySymbol property => property.ExplicitInterfaceImplementations.Any(),
+            IEventSymbol @event => @event.ExplicitInterfaceImplementations.Any(),
+            _ => false
+        };
+}

--- a/src/CodeToNeo4j/FileHandlers/IMemberDependencyExtractor.cs
+++ b/src/CodeToNeo4j/FileHandlers/IMemberDependencyExtractor.cs
@@ -1,0 +1,24 @@
+using CodeToNeo4j.Graph;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeToNeo4j.FileHandlers;
+
+public interface IMemberDependencyExtractor
+{
+    void ExtractMemberDependencies(
+        ISymbol memberSymbol,
+        SyntaxNode memberSyntax,
+        SemanticModel semanticModel,
+        string? repoKey,
+        ICollection<Relationship> relBuffer,
+        Symbol typeRec,
+        Symbol memberRec);
+
+    void AddDependsOnIfExternal(
+        ISymbol? symbol,
+        IAssemblySymbol currentAssembly,
+        string? repoKey,
+        string fromKey,
+        ICollection<Relationship> relBuffer);
+}

--- a/src/CodeToNeo4j/FileHandlers/MemberDependencyExtractor.cs
+++ b/src/CodeToNeo4j/FileHandlers/MemberDependencyExtractor.cs
@@ -1,0 +1,171 @@
+using CodeToNeo4j.Graph;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeToNeo4j.FileHandlers;
+
+public class MemberDependencyExtractor(ISymbolMapper symbolMapper) : IMemberDependencyExtractor
+{
+    public void ExtractMemberDependencies(
+        ISymbol memberSymbol,
+        SyntaxNode memberSyntax,
+        SemanticModel semanticModel,
+        string? repoKey,
+        ICollection<Relationship> relBuffer,
+        Symbol typeRec,
+        Symbol memberRec)
+    {
+        if (memberSyntax is BaseMethodDeclarationSyntax bmds)
+        {
+            ExtractMethodDependencies(bmds, semanticModel, repoKey, relBuffer, typeRec);
+            ExtractMethodExecutes(bmds, memberRec, semanticModel, repoKey, relBuffer);
+        }
+
+        switch (memberSymbol)
+        {
+            case IPropertySymbol propertySymbol:
+                ExtractPropertyDependencies(propertySymbol, repoKey, relBuffer, typeRec);
+                break;
+            case IEventSymbol eventSymbol:
+                ExtractEventDependencies(eventSymbol, repoKey, relBuffer, typeRec);
+                break;
+            case IFieldSymbol fieldSymbol:
+                ExtractFieldDependencies(fieldSymbol, repoKey, relBuffer, typeRec);
+                break;
+        }
+    }
+
+    public void AddDependsOnIfExternal(
+        ISymbol? symbol,
+        IAssemblySymbol currentAssembly,
+        string? repoKey,
+        string fromKey,
+        ICollection<Relationship> relBuffer)
+    {
+        if (symbol == null) return;
+
+        if (symbol is INamespaceSymbol nsSymbol)
+        {
+            if (nsSymbol.ContainingAssembly != null && !SymbolEqualityComparer.Default.Equals(nsSymbol.ContainingAssembly, currentAssembly))
+            {
+                var depKey = $"{repoKey}:{nsSymbol.ToDisplayString()}";
+                if (!relBuffer.Any(r => r.FromKey == fromKey && r.ToKey == depKey && r.RelType == "DEPENDS_ON"))
+                {
+                    relBuffer.Add(new Relationship(FromKey: fromKey, ToKey: depKey, RelType: "DEPENDS_ON"));
+                }
+            }
+        }
+        else if (symbol is INamedTypeSymbol typeSymbol)
+        {
+            if (typeSymbol.ContainingAssembly != null && !SymbolEqualityComparer.Default.Equals(typeSymbol.ContainingAssembly, currentAssembly))
+            {
+                var depKey = $"{repoKey}:{typeSymbol.ToDisplayString()}";
+                if (!relBuffer.Any(r => r.FromKey == fromKey && r.ToKey == depKey && r.RelType == "DEPENDS_ON"))
+                {
+                    relBuffer.Add(new Relationship(FromKey: fromKey, ToKey: depKey, RelType: "DEPENDS_ON"));
+                }
+            }
+        }
+    }
+
+    private void ExtractMethodExecutes(
+        BaseMethodDeclarationSyntax bmds,
+        Symbol callerRec,
+        SemanticModel semanticModel,
+        string? repoKey,
+        ICollection<Relationship> relBuffer)
+    {
+        var body = (SyntaxNode?)bmds.Body ?? bmds.ExpressionBody;
+        if (body == null) return;
+
+        var seenCallees = new HashSet<string>();
+
+        foreach (var invocation in body.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol calleeSymbol) continue;
+            var calleeKey = symbolMapper.BuildStableSymbolKey(repoKey, calleeSymbol);
+            if (seenCallees.Add(calleeKey))
+                relBuffer.Add(new Relationship(FromKey: callerRec.Key, ToKey: calleeKey, RelType: "INVOKES"));
+        }
+
+        foreach (var objectCreation in body.DescendantNodes().OfType<BaseObjectCreationExpressionSyntax>())
+        {
+            if (semanticModel.GetSymbolInfo(objectCreation).Symbol is not IMethodSymbol ctorSymbol) continue;
+            var calleeKey = symbolMapper.BuildStableSymbolKey(repoKey, ctorSymbol);
+            if (seenCallees.Add(calleeKey))
+                relBuffer.Add(new Relationship(FromKey: callerRec.Key, ToKey: calleeKey, RelType: "INVOKES"));
+        }
+    }
+
+    private void ExtractMethodDependencies(
+        BaseMethodDeclarationSyntax bmds,
+        SemanticModel semanticModel,
+        string? repoKey,
+        ICollection<Relationship> relBuffer,
+        Symbol typeRec)
+    {
+        foreach (var parameter in bmds.ParameterList.Parameters)
+        {
+            var parameterSymbol = semanticModel.GetDeclaredSymbol(parameter) as IParameterSymbol;
+            if (parameterSymbol?.Type is not (null or IErrorTypeSymbol))
+            {
+                AddDependsOnRelationship(typeRec.Key, parameterSymbol.Type, repoKey, relBuffer);
+            }
+        }
+
+        if (semanticModel.GetDeclaredSymbol(bmds) is IMethodSymbol { ReturnType: not null and not IErrorTypeSymbol } baseMethodSymbol
+            && baseMethodSymbol.MethodKind != MethodKind.Constructor)
+        {
+            AddDependsOnRelationship(typeRec.Key, baseMethodSymbol.ReturnType, repoKey, relBuffer);
+        }
+    }
+
+    private void ExtractPropertyDependencies(
+        IPropertySymbol propertySymbol,
+        string? repoKey,
+        ICollection<Relationship> relBuffer,
+        Symbol typeRec)
+    {
+        if (propertySymbol.Type is not (null or IErrorTypeSymbol))
+        {
+            AddDependsOnRelationship(typeRec.Key, propertySymbol.Type, repoKey, relBuffer);
+        }
+    }
+
+    private void ExtractEventDependencies(
+        IEventSymbol eventSymbol,
+        string? repoKey,
+        ICollection<Relationship> relBuffer,
+        Symbol typeRec)
+    {
+        var eventType = eventSymbol.Type;
+        if (eventType is INamedTypeSymbol { IsGenericType: true, Name: "Nullable" } namedType)
+        {
+            eventType = namedType.TypeArguments[0];
+        }
+
+        AddDependsOnRelationship(typeRec.Key, eventType, repoKey, relBuffer);
+    }
+
+    private void ExtractFieldDependencies(
+        IFieldSymbol fieldSymbol,
+        string? repoKey,
+        ICollection<Relationship> relBuffer,
+        Symbol typeRec)
+    {
+        if (fieldSymbol.Type is not (null or IErrorTypeSymbol))
+        {
+            AddDependsOnRelationship(typeRec.Key, fieldSymbol.Type, repoKey, relBuffer);
+        }
+    }
+
+    private void AddDependsOnRelationship(
+        string fromKey,
+        ITypeSymbol typeSymbol,
+        string? repoKey,
+        ICollection<Relationship> relBuffer)
+    {
+        var depKey = symbolMapper.BuildStableSymbolKey(repoKey, typeSymbol);
+        relBuffer.Add(new Relationship(FromKey: fromKey, ToKey: depKey, RelType: "DEPENDS_ON"));
+    }
+}

--- a/src/CodeToNeo4j/FileHandlers/RoslynSymbolProcessor.cs
+++ b/src/CodeToNeo4j/FileHandlers/RoslynSymbolProcessor.cs
@@ -19,7 +19,9 @@ public interface IRoslynSymbolProcessor
         Accessibility minAccessibility);
 }
 
-public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolProcessor
+public class RoslynSymbolProcessor(
+    ISymbolMapper symbolMapper,
+    IMemberDependencyExtractor dependencyExtractor) : IRoslynSymbolProcessor
 {
     public void ProcessSyntaxTree(
         SyntaxTree syntaxTree,
@@ -42,12 +44,10 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
 
             if (symbol != null)
             {
-                AddDependsOnIfExternal(symbol, semanticModel.Compilation.Assembly, repoKey, fileKey, relBuffer);
+                dependencyExtractor.AddDependsOnIfExternal(symbol, semanticModel.Compilation.Assembly, repoKey, fileKey, relBuffer);
             }
             else
             {
-                // If the symbol is null, it might be because the assembly is not referenced, 
-                // but we still want to capture it if it's a using
                 var depKey = $"{repoKey}:{usingDirective.Name}";
                 relBuffer.Add(new Relationship(FromKey: fileKey, ToKey: depKey, RelType: "DEPENDS_ON"));
             }
@@ -56,11 +56,6 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
         // Process global usings from the compilation (for the current file)
         if (semanticModel.Compilation is CSharpCompilation)
         {
-            // Usings from the current file are already processed.
-            // We need to find usings that are NOT in the current file but are global usings in the compilation.
-            // Roslyn doesn't make it super easy to find "all global usings that apply to this file but are defined elsewhere" 
-            // through a simple public API without internal access.
-            // However, we can look at all syntax trees in the compilation.
             foreach (var tree in semanticModel.Compilation.SyntaxTrees)
             {
                 if (string.Equals(tree.FilePath, syntaxTree.FilePath, StringComparison.OrdinalIgnoreCase)) continue;
@@ -71,8 +66,7 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
                     if (u.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword) && u.Name != null)
                     {
                         var globalSymbol = semanticModel.Compilation.GetSemanticModel(tree).GetSymbolInfo(u.Name).Symbol;
-                        
-                        // Fallback if the symbol is null (assembly not referenced)
+
                         if (globalSymbol == null)
                         {
                             var depKey = $"{repoKey}:{u.Name}";
@@ -83,7 +77,7 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
                         }
                         else
                         {
-                            AddDependsOnIfExternal(globalSymbol, semanticModel.Compilation.Assembly, repoKey, fileKey, relBuffer);
+                            dependencyExtractor.AddDependsOnIfExternal(globalSymbol, semanticModel.Compilation.Assembly, repoKey, fileKey, relBuffer);
                         }
                     }
                 }
@@ -171,55 +165,25 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
         {
             if (member is EventFieldDeclarationSyntax efds)
             {
-                ProcessEventFieldDeclaration(efds,
-                    semanticModel,
-                    repoKey,
-                    fileKey,
-                    relativePath,
-                    fileNamespace,
-                    symbolBuffer,
-                    relBuffer,
-                    typeRec,
-                    minAccessibility);
-
+                ProcessEventFieldDeclaration(efds, semanticModel, repoKey, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, typeRec, minAccessibility);
                 continue;
             }
 
             if (member is FieldDeclarationSyntax fds)
             {
-                ProcessFieldDeclaration(fds,
-                    semanticModel,
-                    repoKey,
-                    fileKey,
-                    relativePath,
-                    fileNamespace,
-                    symbolBuffer,
-                    relBuffer,
-                    typeRec,
-                    minAccessibility);
-
+                ProcessFieldDeclaration(fds, semanticModel, repoKey, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, typeRec, minAccessibility);
                 continue;
             }
 
             var memberSymbol = semanticModel.GetDeclaredSymbol(member);
-            if (memberSymbol is null && member is EventDeclarationSyntax eds)
+            if (memberSymbol is null && member is EventDeclarationSyntax eventDecl)
             {
-                memberSymbol = semanticModel.GetDeclaredSymbol(eds);
+                memberSymbol = semanticModel.GetDeclaredSymbol(eventDecl);
             }
 
             if (memberSymbol is not null)
             {
-                ProcessMemberSymbol(memberSymbol,
-                    member,
-                    semanticModel,
-                    repoKey,
-                    fileKey,
-                    relativePath,
-                    fileNamespace,
-                    symbolBuffer,
-                    relBuffer,
-                    typeRec,
-                    minAccessibility);
+                ProcessMemberSymbol(memberSymbol, member, semanticModel, repoKey, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, typeRec, minAccessibility);
             }
         }
     }
@@ -240,17 +204,7 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
         {
             if (semanticModel.GetDeclaredSymbol(variable) is IFieldSymbol variableSymbol)
             {
-                ProcessMemberSymbol(variableSymbol,
-                    variable,
-                    semanticModel,
-                    repoKey,
-                    fileKey,
-                    relativePath,
-                    fileNamespace,
-                    symbolBuffer,
-                    relBuffer,
-                    typeRec,
-                    minAccessibility);
+                ProcessMemberSymbol(variableSymbol, variable, semanticModel, repoKey, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, typeRec, minAccessibility);
             }
         }
     }
@@ -271,17 +225,7 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
         {
             if (semanticModel.GetDeclaredSymbol(variable) is IEventSymbol variableSymbol)
             {
-                ProcessMemberSymbol(variableSymbol,
-                    variable,
-                    semanticModel,
-                    repoKey,
-                    fileKey,
-                    relativePath,
-                    fileNamespace,
-                    symbolBuffer,
-                    relBuffer,
-                    typeRec,
-                    minAccessibility);
+                ProcessMemberSymbol(variableSymbol, variable, semanticModel, repoKey, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, typeRec, minAccessibility);
             }
         }
     }
@@ -299,7 +243,7 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
         Symbol typeRec,
         Accessibility minAccessibility)
     {
-        if (IsAccessibilityBelowMinimum(memberSymbol, minAccessibility))
+        if (AccessibilityFilter.IsAccessibilityBelowMinimum(memberSymbol, minAccessibility))
         {
             return;
         }
@@ -309,189 +253,6 @@ public class RoslynSymbolProcessor(ISymbolMapper symbolMapper) : IRoslynSymbolPr
 
         relBuffer.Add(new Relationship(FromKey: typeRec.Key, ToKey: memberRec.Key, RelType: "CONTAINS"));
 
-        ExtractMemberDependencies(memberSymbol,
-            memberSyntax,
-            semanticModel,
-            repoKey,
-            relBuffer,
-            typeRec,
-            memberRec);
+        dependencyExtractor.ExtractMemberDependencies(memberSymbol, memberSyntax, semanticModel, repoKey, relBuffer, typeRec, memberRec);
     }
-
-    private void ExtractMemberDependencies(
-        ISymbol memberSymbol,
-        SyntaxNode memberSyntax,
-        SemanticModel semanticModel,
-        string? repoKey,
-        ICollection<Relationship> relBuffer,
-        Symbol typeRec,
-        Symbol memberRec)
-    {
-        if (memberSyntax is BaseMethodDeclarationSyntax bmds)
-        {
-            ExtractMethodDependencies(bmds, semanticModel, repoKey, relBuffer, typeRec);
-            ExtractMethodExecutes(bmds, memberRec, semanticModel, repoKey, relBuffer);
-        }
-
-        switch (memberSymbol)
-        {
-            case IPropertySymbol propertySymbol:
-                ExtractPropertyDependencies(propertySymbol, repoKey, relBuffer, typeRec);
-                break;
-            case IEventSymbol eventSymbol:
-                ExtractEventDependencies(eventSymbol, repoKey, relBuffer, typeRec);
-                break;
-            case IFieldSymbol fieldSymbol:
-                ExtractFieldDependencies(fieldSymbol, repoKey, relBuffer, typeRec);
-                break;
-        }
-    }
-
-    private void ExtractMethodExecutes(
-        BaseMethodDeclarationSyntax bmds,
-        Symbol callerRec,
-        SemanticModel semanticModel,
-        string? repoKey,
-        ICollection<Relationship> relBuffer)
-    {
-        var body = (SyntaxNode?)bmds.Body ?? bmds.ExpressionBody;
-        if (body == null) return;
-
-        var seenCallees = new HashSet<string>();
-
-        foreach (var invocation in body.DescendantNodes().OfType<InvocationExpressionSyntax>())
-        {
-            if (semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol calleeSymbol) continue;
-            var calleeKey = symbolMapper.BuildStableSymbolKey(repoKey, calleeSymbol);
-            if (seenCallees.Add(calleeKey))
-                relBuffer.Add(new Relationship(FromKey: callerRec.Key, ToKey: calleeKey, RelType: "INVOKES"));
-        }
-
-        foreach (var objectCreation in body.DescendantNodes().OfType<BaseObjectCreationExpressionSyntax>())
-        {
-            if (semanticModel.GetSymbolInfo(objectCreation).Symbol is not IMethodSymbol ctorSymbol) continue;
-            var calleeKey = symbolMapper.BuildStableSymbolKey(repoKey, ctorSymbol);
-            if (seenCallees.Add(calleeKey))
-                relBuffer.Add(new Relationship(FromKey: callerRec.Key, ToKey: calleeKey, RelType: "INVOKES"));
-        }
-    }
-
-    private void ExtractMethodDependencies(
-        BaseMethodDeclarationSyntax bmds,
-        SemanticModel semanticModel,
-        string? repoKey,
-        ICollection<Relationship> relBuffer,
-        Symbol typeRec)
-    {
-        foreach (var parameter in bmds.ParameterList.Parameters)
-        {
-            var parameterSymbol = semanticModel.GetDeclaredSymbol(parameter) as IParameterSymbol;
-            if (parameterSymbol?.Type is not (null or IErrorTypeSymbol))
-            {
-                AddDependsOnRelationship(typeRec.Key, parameterSymbol.Type, repoKey, relBuffer);
-            }
-        }
-
-        if (semanticModel.GetDeclaredSymbol(bmds) is IMethodSymbol { ReturnType: not null and not IErrorTypeSymbol } baseMethodSymbol
-            && baseMethodSymbol.MethodKind != MethodKind.Constructor)
-        {
-            AddDependsOnRelationship(typeRec.Key, baseMethodSymbol.ReturnType, repoKey, relBuffer);
-        }
-    }
-
-    private void ExtractPropertyDependencies(
-        IPropertySymbol propertySymbol,
-        string? repoKey,
-        ICollection<Relationship> relBuffer,
-        Symbol typeRec)
-    {
-        if (propertySymbol.Type is not (null or IErrorTypeSymbol))
-        {
-            AddDependsOnRelationship(typeRec.Key, propertySymbol.Type, repoKey, relBuffer);
-        }
-    }
-
-    private void ExtractEventDependencies(
-        IEventSymbol eventSymbol,
-        string? repoKey,
-        ICollection<Relationship> relBuffer,
-        Symbol typeRec)
-    {
-        var eventType = eventSymbol.Type;
-        if (eventType is INamedTypeSymbol { IsGenericType: true, Name: "Nullable" } namedType)
-        {
-            eventType = namedType.TypeArguments[0];
-        }
-
-        AddDependsOnRelationship(typeRec.Key, eventType, repoKey, relBuffer);
-    }
-
-    private void ExtractFieldDependencies(
-        IFieldSymbol fieldSymbol,
-        string? repoKey,
-        ICollection<Relationship> relBuffer,
-        Symbol typeRec)
-    {
-        if (fieldSymbol.Type is not (null or IErrorTypeSymbol))
-        {
-            AddDependsOnRelationship(typeRec.Key, fieldSymbol.Type, repoKey, relBuffer);
-        }
-    }
-
-    private void AddDependsOnIfExternal(
-        ISymbol? symbol,
-        IAssemblySymbol currentAssembly,
-        string? repoKey,
-        string fromKey,
-        ICollection<Relationship> relBuffer)
-    {
-        if (symbol == null) return;
-
-        if (symbol is INamespaceSymbol nsSymbol)
-        {
-            if (nsSymbol.ContainingAssembly != null && !SymbolEqualityComparer.Default.Equals(nsSymbol.ContainingAssembly, currentAssembly))
-            {
-                var depKey = $"{repoKey}:{nsSymbol.ToDisplayString()}";
-                if (!relBuffer.Any(r => r.FromKey == fromKey && r.ToKey == depKey && r.RelType == "DEPENDS_ON"))
-                {
-                    relBuffer.Add(new Relationship(FromKey: fromKey, ToKey: depKey, RelType: "DEPENDS_ON"));
-                }
-            }
-        }
-        else if (symbol is INamedTypeSymbol typeSymbol)
-        {
-            if (typeSymbol.ContainingAssembly != null && !SymbolEqualityComparer.Default.Equals(typeSymbol.ContainingAssembly, currentAssembly))
-            {
-                var depKey = $"{repoKey}:{typeSymbol.ToDisplayString()}";
-                if (!relBuffer.Any(r => r.FromKey == fromKey && r.ToKey == depKey && r.RelType == "DEPENDS_ON"))
-                {
-                    relBuffer.Add(new Relationship(FromKey: fromKey, ToKey: depKey, RelType: "DEPENDS_ON"));
-                }
-            }
-        }
-    }
-
-    private void AddDependsOnRelationship(
-        string fromKey,
-        ITypeSymbol typeSymbol,
-        string? repoKey,
-        ICollection<Relationship> relBuffer)
-    {
-        var depKey = symbolMapper.BuildStableSymbolKey(repoKey, typeSymbol);
-        relBuffer.Add(new Relationship(FromKey: fromKey, ToKey: depKey, RelType: "DEPENDS_ON"));
-    }
-
-    private static bool IsAccessibilityBelowMinimum(ISymbol symbol, Accessibility minAccessibility) =>
-        symbol.DeclaredAccessibility < minAccessibility
-        && symbol.DeclaredAccessibility != Accessibility.NotApplicable
-        && !IsExplicitInterfaceImplementation(symbol);
-
-    private static bool IsExplicitInterfaceImplementation(ISymbol symbol) =>
-        symbol switch
-        {
-            IMethodSymbol method => method.ExplicitInterfaceImplementations.Any(),
-            IPropertySymbol property => property.ExplicitInterfaceImplementations.Any(),
-            IEventSymbol @event => @event.ExplicitInterfaceImplementations.Any(),
-            _ => false
-        };
 }

--- a/src/CodeToNeo4j/Neo4j/INeo4jFlushService.cs
+++ b/src/CodeToNeo4j/Neo4j/INeo4jFlushService.cs
@@ -1,0 +1,10 @@
+using CodeToNeo4j.Graph;
+
+namespace CodeToNeo4j.Neo4j;
+
+public interface INeo4jFlushService
+{
+    Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName);
+    Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName);
+    Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName);
+}

--- a/src/CodeToNeo4j/Neo4j/INeo4jSchemaService.cs
+++ b/src/CodeToNeo4j/Neo4j/INeo4jSchemaService.cs
@@ -1,0 +1,6 @@
+namespace CodeToNeo4j.Neo4j;
+
+public interface INeo4jSchemaService
+{
+    Task Initialize(string? repoKey, string databaseName);
+}

--- a/src/CodeToNeo4j/Neo4j/Neo4jFlushService.cs
+++ b/src/CodeToNeo4j/Neo4j/Neo4jFlushService.cs
@@ -1,0 +1,142 @@
+using CodeToNeo4j.Cypher;
+using CodeToNeo4j.Graph;
+using Neo4j.Driver;
+using Microsoft.Extensions.Logging;
+
+namespace CodeToNeo4j.Neo4j;
+
+public class Neo4jFlushService(
+    IDriver driver,
+    ICypherService cypherService,
+    ILogger<Neo4jFlushService> logger) : INeo4jFlushService
+{
+    public async Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName)
+    {
+        var fileBatch = files.Select(file => new Dictionary<string, object?>
+        {
+            ["fileKey"] = file.FileKey,
+            ["fileName"] = file.FileName,
+            ["path"] = file.RelativePath,
+            ["namespace"] = file.Namespace,
+            ["hash"] = file.FileHash,
+            ["created"] = file.Metadata.Created.ToString("O"),
+            ["lastModified"] = file.Metadata.LastModified.ToString("O"),
+            ["authors"] = file.Metadata.Authors.Select(a => new Dictionary<string, object?>
+            {
+                ["name"] = a.Name,
+                ["firstCommit"] = a.FirstCommit.ToString("O"),
+                ["lastCommit"] = a.LastCommit.ToString("O"),
+                ["commitCount"] = a.CommitCount
+            }).ToArray(),
+            ["commits"] = file.Metadata.Commits.ToArray(),
+            ["tags"] = file.Metadata.Tags.ToArray(),
+            ["repoKey"] = file.RepoKey
+        }).ToArray();
+
+        if (fileBatch.Length == 0)
+        {
+            return;
+        }
+
+        logger.LogDebug("Flushing {Count} files to Neo4j (Database: {DatabaseName})...", fileBatch.Length, databaseName);
+
+        var fileKeys = fileBatch.Select(f => f["fileKey"]).ToArray();
+
+        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
+        await session.ExecuteWriteAsync(async tx =>
+        {
+            await tx.RunWithRetry(cypherService.GetCypher(Queries.DeletePriorSymbols), new { fileKeys }).ConfigureAwait(false);
+            await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertFile), new { files = fileBatch }).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+    }
+
+    public async Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName)
+    {
+        var symbolBatch = symbols.Select(s => new Dictionary<string, object?>
+        {
+            ["key"] = s.Key,
+            ["name"] = s.Name,
+            ["kind"] = s.Kind,
+            ["class"] = s.Class,
+            ["fqn"] = s.Fqn,
+            ["accessibility"] = s.Accessibility,
+            ["fileKey"] = s.FileKey,
+            ["filePath"] = s.RelativePath,
+            ["namespace"] = s.Namespace,
+            ["startLine"] = s.StartLine,
+            ["endLine"] = s.EndLine,
+            ["documentation"] = s.Documentation,
+            ["comments"] = s.Comments,
+            ["version"] = s.Version
+        }).ToArray();
+
+        var relBatch = relationships.Select(r => new Dictionary<string, object?>
+        {
+            ["fromKey"] = r.FromKey,
+            ["toKey"] = r.ToKey,
+            ["relType"] = r.RelType
+        }).ToArray();
+
+        var tagBatch = symbols
+            .Where(s => !string.IsNullOrWhiteSpace(s.Namespace))
+            .Select(s => new Dictionary<string, object?>
+            {
+                ["symbolKey"] = s.Key,
+                ["tags"] = NamespaceTagParser.ParseTags(s.Namespace).ToArray()
+            })
+            .Where(x => ((string[])x["tags"]!).Length > 0)
+            .ToArray();
+
+        if (symbolBatch.Length == 0 && relBatch.Length == 0) return;
+
+        logger.LogDebug("Flushing {SymbolCount} symbols and {RelCount} relationships to Neo4j (Database: {DatabaseName})...", symbolBatch.Length, relBatch.Length, databaseName);
+
+        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
+        await session.ExecuteWriteAsync(async tx =>
+        {
+            var tasks = new List<Task>();
+
+            if (symbolBatch.Length > 0)
+            {
+                tasks.Add(tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertSymbols), new { symbols = symbolBatch }));
+            }
+
+            if (relBatch.Length > 0)
+            {
+                tasks.Add(tx.RunWithRetry(cypherService.GetCypher(Queries.MergeRelationships), new { rels = relBatch }));
+            }
+
+            if (tasks.Count > 0)
+            {
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
+
+        if (tagBatch.Length > 0)
+        {
+            logger.LogDebug("Upserting namespace tags for {Count} symbols (Database: {DatabaseName})...", tagBatch.Length, databaseName);
+            await using var tagSession = driver.AsyncSession(o => o.WithDatabase(databaseName));
+            await tagSession.ExecuteWriteAsync(async tx =>
+            {
+                await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertTags), new { symbolTags = tagBatch }).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+        }
+    }
+
+    public async Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName)
+    {
+        var urlBatch = urlNodes.Select(u => new Dictionary<string, object?>
+        {
+            ["depKey"] = u.DepKey,
+            ["urlKey"] = u.UrlKey,
+            ["name"] = u.Name
+        }).ToArray();
+
+        if (urlBatch.Length == 0) return;
+
+        logger.LogDebug("Upserting {Count} dependency URL nodes in database: {DatabaseName}", urlBatch.Length, databaseName);
+        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
+        await session.ExecuteWriteAsync(async tx => await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertDependencyUrls), new { urls = urlBatch }))
+            .ConfigureAwait(false);
+    }
+}

--- a/src/CodeToNeo4j/Neo4j/Neo4jSchemaService.cs
+++ b/src/CodeToNeo4j/Neo4j/Neo4jSchemaService.cs
@@ -1,0 +1,90 @@
+using CodeToNeo4j.Cypher;
+using Neo4j.Driver;
+using Microsoft.Extensions.Logging;
+
+namespace CodeToNeo4j.Neo4j;
+
+public class Neo4jSchemaService(
+    IDriver driver,
+    ICypherService cypherService,
+    ILogger<Neo4jSchemaService> logger) : INeo4jSchemaService
+{
+    public async Task Initialize(string? repoKey, string databaseName)
+    {
+        logger.LogInformation("Initializing Neo4j driver...");
+
+        await VerifyNeo4jVersion().ConfigureAwait(false);
+        logger.LogInformation("Neo4j version verified.");
+
+        await EnsureSchema(databaseName).ConfigureAwait(false);
+        logger.LogInformation("Neo4j schema ensured for database: {DatabaseName}", databaseName);
+
+        if (repoKey is not null)
+        {
+            await UpsertProject(repoKey, databaseName).ConfigureAwait(false);
+            logger.LogInformation("Project upserted: {RepositoryKey}", repoKey);
+        }
+    }
+
+    private async Task VerifyNeo4jVersion()
+    {
+        logger.LogDebug("Verifying Neo4j version...");
+        await using var session = driver.AsyncSession();
+        var result = await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.GetNeo4jVersion)).ConfigureAwait(false);
+            return await cursor.SingleAsync().ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var versionString = result["version"].As<string>();
+        if (string.IsNullOrWhiteSpace(versionString))
+        {
+            throw new NotSupportedException("Could not determine Neo4j version.");
+        }
+
+        logger.LogDebug("Detected Neo4j version: {VersionString}", versionString);
+
+        var versionSpan = versionString.AsSpan();
+        var hyphenIndex = versionSpan.IndexOf('-');
+        var versionPart = hyphenIndex == -1 ? versionSpan : versionSpan[..hyphenIndex];
+
+        if (Version.TryParse(versionPart, out var version))
+        {
+            if (version.Major < 5)
+            {
+                throw new NotSupportedException($"Neo4j version {versionString} is not supported. Minimum required version is 5.0.");
+            }
+        }
+        else
+        {
+            if (versionSpan.Length > 0 && char.IsDigit(versionSpan[0]) && int.TryParse(versionSpan[..1], out var major) && major < 5)
+            {
+                throw new NotSupportedException($"Neo4j version {versionString} is not supported. Minimum required version is 5.0.");
+            }
+        }
+    }
+
+    private async Task EnsureSchema(string databaseName)
+    {
+        if (databaseName.Any(char.IsUpper))
+        {
+            logger.LogWarning("Database name '{DatabaseName}' contains uppercase letters. Neo4j 5.0+ usually requires lowercase database names. This may cause connection issues or use the wrong database.", databaseName);
+        }
+
+        logger.LogDebug("Ensuring schema for database: {DatabaseName}", databaseName);
+        var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
+        var schema = cypherService.GetCypher(Queries.Schema);
+        var statements = schema.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        await Task.WhenAll(statements.Select(cypher => session.RunWithRetry(cypher)))
+            .ContinueWith(async _ => await session.DisposeAsync());
+    }
+
+    private async Task UpsertProject(string repoKey, string databaseName)
+    {
+        logger.LogDebug("Upserting project: {RepoKey} in database: {DatabaseName}", repoKey, databaseName);
+        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
+        await session.ExecuteWriteAsync(async tx => await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertProject), new { key = repoKey, name = repoKey }))
+            .ConfigureAwait(false);
+    }
+}

--- a/src/CodeToNeo4j/Neo4j/Neo4jService.cs
+++ b/src/CodeToNeo4j/Neo4j/Neo4jService.cs
@@ -11,6 +11,8 @@ public class Neo4jService(
     IDriver driver,
     ICypherService cypherService,
     IFileService fileService,
+    INeo4jSchemaService schemaService,
+    INeo4jFlushService flushService,
     ILogger<Neo4jService> logger)
     : IGraphService, IAsyncDisposable, IDisposable
 {
@@ -28,22 +30,8 @@ public class Neo4jService(
         GC.SuppressFinalize(this);
     }
 
-    public async Task Initialize(string? repoKey, string databaseName)
-    {
-        logger.LogInformation("Initializing Neo4j driver...");
-
-        await VerifyNeo4jVersion().ConfigureAwait(false);
-        logger.LogInformation("Neo4j version verified.");
-
-        await EnsureSchema(databaseName).ConfigureAwait(false);
-        logger.LogInformation("Neo4j schema ensured for database: {DatabaseName}", databaseName);
-
-        if (repoKey is not null)
-        {
-            await UpsertProject(repoKey, databaseName).ConfigureAwait(false);
-            logger.LogInformation("Project upserted: {RepositoryKey}", repoKey);
-        }
-    }
+    public Task Initialize(string? repoKey, string databaseName) =>
+        schemaService.Initialize(repoKey, databaseName);
 
     public async Task MarkFileAsDeleted(string filePath, string databaseName)
     {
@@ -101,135 +89,14 @@ public class Neo4jService(
             .ConfigureAwait(false);
     }
 
-    public async Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName)
-    {
-        var fileBatch = files.Select(file => new Dictionary<string, object?>
-        {
-            ["fileKey"] = file.FileKey,
-            ["fileName"] = file.FileName,
-            ["path"] = file.RelativePath,
-            ["namespace"] = file.Namespace,
-            ["hash"] = file.FileHash,
-            ["created"] = file.Metadata.Created.ToString("O"),
-            ["lastModified"] = file.Metadata.LastModified.ToString("O"),
-            ["authors"] = file.Metadata.Authors.Select(a => new Dictionary<string, object?>
-            {
-                ["name"] = a.Name,
-                ["firstCommit"] = a.FirstCommit.ToString("O"),
-                ["lastCommit"] = a.LastCommit.ToString("O"),
-                ["commitCount"] = a.CommitCount
-            }).ToArray(),
-            ["commits"] = file.Metadata.Commits.ToArray(),
-            ["tags"] = file.Metadata.Tags.ToArray(),
-            ["repoKey"] = file.RepoKey
-        }).ToArray();
+    public Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName) =>
+        flushService.FlushFiles(files, databaseName);
 
-        if (fileBatch.Length == 0)
-        {
-            return;
-        }
+    public Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName) =>
+        flushService.FlushSymbols(symbols, relationships, databaseName);
 
-        logger.LogDebug("Flushing {Count} files to Neo4j (Database: {DatabaseName})...", fileBatch.Length, databaseName);
-
-        var fileKeys = fileBatch.Select(f => f["fileKey"]).ToArray();
-
-        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
-        await session.ExecuteWriteAsync(async tx =>
-        {
-            await tx.RunWithRetry(cypherService.GetCypher(Queries.DeletePriorSymbols), new { fileKeys }).ConfigureAwait(false);
-            await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertFile), new { files = fileBatch }).ConfigureAwait(false);
-        }).ConfigureAwait(false);
-    }
-
-    public async Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName)
-    {
-        var symbolBatch = symbols.Select(s => new Dictionary<string, object?>
-        {
-            ["key"] = s.Key,
-            ["name"] = s.Name,
-            ["kind"] = s.Kind,
-            ["class"] = s.Class,
-            ["fqn"] = s.Fqn,
-            ["accessibility"] = s.Accessibility,
-            ["fileKey"] = s.FileKey,
-            ["filePath"] = s.RelativePath,
-            ["namespace"] = s.Namespace,
-            ["startLine"] = s.StartLine,
-            ["endLine"] = s.EndLine,
-            ["documentation"] = s.Documentation,
-            ["comments"] = s.Comments,
-            ["version"] = s.Version
-        }).ToArray();
-
-        var relBatch = relationships.Select(r => new Dictionary<string, object?>
-        {
-            ["fromKey"] = r.FromKey,
-            ["toKey"] = r.ToKey,
-            ["relType"] = r.RelType
-        }).ToArray();
-
-        var tagBatch = symbols
-            .Where(s => !string.IsNullOrWhiteSpace(s.Namespace))
-            .Select(s => new Dictionary<string, object?>
-            {
-                ["symbolKey"] = s.Key,
-                ["tags"] = NamespaceTagParser.ParseTags(s.Namespace).ToArray()
-            })
-            .Where(x => ((string[])x["tags"]!).Length > 0)
-            .ToArray();
-
-        if (symbolBatch.Length == 0 && relBatch.Length == 0) return;
-
-        logger.LogDebug("Flushing {SymbolCount} symbols and {RelCount} relationships to Neo4j (Database: {DatabaseName})...", symbolBatch.Length, relBatch.Length, databaseName);
-
-        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
-        await session.ExecuteWriteAsync(async tx =>
-        {
-            var tasks = new List<Task>();
-
-            if (symbolBatch.Length > 0)
-            {
-                tasks.Add(tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertSymbols), new { symbols = symbolBatch }));
-            }
-
-            if (relBatch.Length > 0)
-            {
-                tasks.Add(tx.RunWithRetry(cypherService.GetCypher(Queries.MergeRelationships), new { rels = relBatch }));
-            }
-
-            if (tasks.Count > 0)
-            {
-                await Task.WhenAll(tasks).ConfigureAwait(false);
-            }
-        }).ConfigureAwait(false);
-
-        if (tagBatch.Length > 0)
-        {
-            logger.LogDebug("Upserting namespace tags for {Count} symbols (Database: {DatabaseName})...", tagBatch.Length, databaseName);
-            await using var tagSession = driver.AsyncSession(o => o.WithDatabase(databaseName));
-            await tagSession.ExecuteWriteAsync(async tx =>
-            {
-                await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertTags), new { symbolTags = tagBatch }).ConfigureAwait(false);
-            }).ConfigureAwait(false);
-        }
-    }
-
-    public async Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName)
-    {
-        var urlBatch = urlNodes.Select(u => new Dictionary<string, object?>
-        {
-            ["depKey"] = u.DepKey,
-            ["urlKey"] = u.UrlKey,
-            ["name"] = u.Name
-        }).ToArray();
-
-        if (urlBatch.Length == 0) return;
-
-        logger.LogDebug("Upserting {Count} dependency URL nodes in database: {DatabaseName}", urlBatch.Length, databaseName);
-        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
-        await session.ExecuteWriteAsync(async tx => await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertDependencyUrls), new { urls = urlBatch }))
-            .ConfigureAwait(false);
-    }
+    public Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName) =>
+        flushService.UpsertDependencyUrls(urlNodes, databaseName);
 
     public async Task PurgeData(string? repoKey, IEnumerable<string>? includeExtensions, string databaseName, bool purgeDependencies, int batchSize)
     {
@@ -258,7 +125,6 @@ public class Neo4jService(
         logger.LogInformation("Purge complete for {PurgeTarget}. Total items deleted: {TotalDeleted}", purgeTarget, totalDeleted);
     }
 
-
     protected virtual void Dispose(bool disposing)
     {
         if (disposing)
@@ -276,67 +142,5 @@ public class Neo4jService(
     ~Neo4jService()
     {
         Dispose(false);
-    }
-
-    private async Task VerifyNeo4jVersion()
-    {
-        logger.LogDebug("Verifying Neo4j version...");
-        await using var session = driver.AsyncSession();
-        var result = await session.ExecuteReadAsync(async tx =>
-        {
-            var cursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.GetNeo4jVersion)).ConfigureAwait(false);
-            return await cursor.SingleAsync().ConfigureAwait(false);
-        }).ConfigureAwait(false);
-
-        var versionString = result["version"].As<string>();
-        if (string.IsNullOrWhiteSpace(versionString))
-        {
-            throw new NotSupportedException("Could not determine Neo4j version.");
-        }
-
-        logger.LogDebug("Detected Neo4j version: {VersionString}", versionString);
-
-        var versionSpan = versionString.AsSpan();
-        var hyphenIndex = versionSpan.IndexOf('-');
-        var versionPart = hyphenIndex == -1 ? versionSpan : versionSpan[..hyphenIndex];
-
-        if (Version.TryParse(versionPart, out var version))
-        {
-            if (version.Major < 5)
-            {
-                throw new NotSupportedException($"Neo4j version {versionString} is not supported. Minimum required version is 5.0.");
-            }
-        }
-        else
-        {
-            if (versionSpan.Length > 0 && char.IsDigit(versionSpan[0]) && int.TryParse(versionSpan[..1], out var major) && major < 5)
-            {
-                throw new NotSupportedException($"Neo4j version {versionString} is not supported. Minimum required version is 5.0.");
-            }
-        }
-    }
-
-    private async Task EnsureSchema(string databaseName)
-    {
-        if (databaseName.Any(char.IsUpper))
-        {
-            logger.LogWarning("Database name '{DatabaseName}' contains uppercase letters. Neo4j 5.0+ usually requires lowercase database names. This may cause connection issues or use the wrong database.", databaseName);
-        }
-
-        logger.LogDebug("Ensuring schema for database: {DatabaseName}", databaseName);
-        var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
-        var schema = cypherService.GetCypher(Queries.Schema);
-        var statements = schema.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        await Task.WhenAll(statements.Select(cypher => session.RunWithRetry(cypher)))
-            .ContinueWith(async _ => await session.DisposeAsync());
-    }
-
-    private async Task UpsertProject(string repoKey, string databaseName)
-    {
-        logger.LogDebug("Upserting project: {RepoKey} in database: {DatabaseName}", repoKey, databaseName);
-        await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
-        await session.ExecuteWriteAsync(async tx => await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertProject), new { key = repoKey, name = repoKey }))
-            .ConfigureAwait(false);
     }
 }

--- a/src/CodeToNeo4j/Solution/CommitIngestionService.cs
+++ b/src/CodeToNeo4j/Solution/CommitIngestionService.cs
@@ -1,0 +1,27 @@
+using CodeToNeo4j.Graph;
+using CodeToNeo4j.VersionControl;
+using Microsoft.Extensions.Logging;
+
+namespace CodeToNeo4j.Solution;
+
+public class CommitIngestionService(
+    IVersionControlService versionControlService,
+    IGraphService graphService,
+    ILogger<CommitIngestionService> logger) : ICommitIngestionService
+{
+    public async Task IngestCommits(string diffBase, string solutionRoot, string? repoKey, string databaseName, int batchSize)
+    {
+        var totalCommits = await versionControlService.GetCommitCount(diffBase, solutionRoot).ConfigureAwait(false);
+        if (totalCommits <= 0) return;
+
+        logger.LogInformation("Ingesting {Count} commits since {DiffBase} in parallel batches...", totalCommits, diffBase);
+        var parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = Math.Max(2, Environment.ProcessorCount) };
+        var skipValues = Enumerable.Range(0, (totalCommits + batchSize - 1) / batchSize).Select(i => i * batchSize).ToArray();
+
+        await Parallel.ForEachAsync(skipValues, parallelOptions, async (skip, _) =>
+        {
+            var commits = await versionControlService.GetCommitBatch(diffBase, solutionRoot, batchSize, skip).ConfigureAwait(false);
+            await graphService.UpsertCommits(repoKey, solutionRoot, commits, databaseName).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+    }
+}

--- a/src/CodeToNeo4j/Solution/ICommitIngestionService.cs
+++ b/src/CodeToNeo4j/Solution/ICommitIngestionService.cs
@@ -1,0 +1,6 @@
+namespace CodeToNeo4j.Solution;
+
+public interface ICommitIngestionService
+{
+    Task IngestCommits(string diffBase, string solutionRoot, string? repoKey, string databaseName, int batchSize);
+}

--- a/src/CodeToNeo4j/Solution/SolutionProcessor.cs
+++ b/src/CodeToNeo4j/Solution/SolutionProcessor.cs
@@ -20,6 +20,7 @@ public class SolutionProcessor(
     IEnumerable<IDocumentHandler> handlers,
     IDependencyIngestor dependencyIngestor,
     ISolutionFileDiscoveryService discoveryService,
+    ICommitIngestionService commitIngestionService,
     ILogger<SolutionProcessor> logger) : ISolutionProcessor
 {
     private readonly HandlerLookup _handlerLookup = new(handlers);
@@ -92,17 +93,7 @@ public class SolutionProcessor(
 
         if (diffBase is not null)
         {
-            var totalCommits = await versionControlService.GetCommitCount(diffBase, solutionRoot).ConfigureAwait(false);
-            if (totalCommits > 0)
-            {
-                logger.LogInformation("Ingesting {Count} commits since {DiffBase} in parallel batches...", totalCommits, diffBase);
-                var skipValues = Enumerable.Range(0, (totalCommits + batchSize - 1) / batchSize).Select(i => i * batchSize).ToArray();
-                await Parallel.ForEachAsync(skipValues, parallelOptions, async (skip, _) =>
-                {
-                    var commits = await versionControlService.GetCommitBatch(diffBase, solutionRoot, batchSize, skip).ConfigureAwait(false);
-                    await graphService.UpsertCommits(repoKey, solutionRoot, commits, databaseName).ConfigureAwait(false);
-                }).ConfigureAwait(false);
-            }
+            await commitIngestionService.IngestCommits(diffBase, solutionRoot, repoKey, databaseName, batchSize).ConfigureAwait(false);
         }
 
         logger.LogInformation("Processing complete.");
@@ -181,31 +172,6 @@ public class SolutionProcessor(
         }
     }
 
-    private static ProcessedFile[] FilterFiles(IEnumerable<ProcessedFile> discoveredFiles, HashSet<string>? changedFiles)
-    {
-        var result = discoveredFiles.ToArray();
-
-        switch (changedFiles?.Any() ?? false)
-        {
-            case true:
-                result = result
-                    .Where(f => changedFiles.Contains(f.FilePath))
-                    .ToArray();
-                break;
-            default:
-            {
-                if (changedFiles is not null)
-                {
-                    result = [];
-                }
-
-                break;
-            }
-        }
-
-        return result;
-    }
-
     private async Task<DiffResult?> GetChangedFiles(FileInfo sln, string? diffBase, HashSet<string> includeExtensions)
     {
         if (diffBase is null) return null;
@@ -269,6 +235,31 @@ public class SolutionProcessor(
         var fileRecord = new FileMetaData(finalFileKey, fileName, relativePath, fileHash, metadata, repoKey, finalNamespace);
 
         return new ProcessResult(fileRecord, symbols, relationships, urlNodes, relativePath);
+    }
+
+    private static ProcessedFile[] FilterFiles(IEnumerable<ProcessedFile> discoveredFiles, HashSet<string>? changedFiles)
+    {
+        var result = discoveredFiles.ToArray();
+
+        switch (changedFiles?.Any() ?? false)
+        {
+            case true:
+                result = result
+                    .Where(f => changedFiles.Contains(f.FilePath))
+                    .ToArray();
+                break;
+            default:
+            {
+                if (changedFiles is not null)
+                {
+                    result = [];
+                }
+
+                break;
+            }
+        }
+
+        return result;
     }
 
     private record ProcessResult(

--- a/src/CodeToNeo4j/VersionControl/GitLogParser.cs
+++ b/src/CodeToNeo4j/VersionControl/GitLogParser.cs
@@ -1,0 +1,134 @@
+using System.IO.Abstractions;
+using CodeToNeo4j.FileSystem;
+
+namespace CodeToNeo4j.VersionControl;
+
+public class GitLogParser(
+    IFileService fileService,
+    IFileSystem fileSystem) : IGitLogParser
+{
+    public IEnumerable<CommitMetadata> ParseCommits(string output, string repoRoot)
+    {
+        var commits = new List<CommitMetadata>();
+        var lines = output.Split('\n', StringSplitOptions.TrimEntries);
+        CommitMetadata? currentCommit = null;
+        var changedFiles = new List<FileStatus>();
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            if (line.StartsWith("COMMIT|"))
+            {
+                if (currentCommit != null)
+                {
+                    commits.Add(currentCommit with { ChangedFiles = [.. changedFiles] });
+                    changedFiles = [];
+                }
+
+                var headerParts = line["COMMIT|".Length..].Split("|#|", 5, StringSplitOptions.None);
+                if (headerParts.Length >= 5)
+                {
+                    if (DateTimeOffset.TryParse(headerParts[3], out var date))
+                    {
+                        currentCommit = new CommitMetadata(headerParts[0], headerParts[1], headerParts[2], date, headerParts[4], []);
+                    }
+                }
+            }
+            else
+            {
+                if (currentCommit != null)
+                {
+                    var fileParts = line.Split('\t', StringSplitOptions.RemoveEmptyEntries);
+                    if (fileParts.Length >= 2)
+                    {
+                        var status = fileParts[0];
+                        var relPath = fileParts[1];
+                        var fullPath = fileService.NormalizePath(fileSystem.Path.Combine(repoRoot, relPath));
+                        changedFiles.Add(new FileStatus(fullPath, status.StartsWith('D')));
+                    }
+                }
+            }
+        }
+
+        if (currentCommit != null)
+        {
+            commits.Add(currentCommit with { ChangedFiles = [.. changedFiles] });
+        }
+
+        return commits;
+    }
+
+    public FileMetadata BuildFileMetadata(
+        IList<(string Author, DateTimeOffset Date, string Hash, string? Refs)> history)
+    {
+        var authorMap = new Dictionary<string, (DateTimeOffset first, DateTimeOffset last, int count)>();
+        var created = DateTimeOffset.MaxValue;
+        var lastModified = DateTimeOffset.MinValue;
+        var hashes = new List<string>();
+        var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var commit in history)
+        {
+            if (commit.Date < created) created = commit.Date;
+            if (commit.Date > lastModified) lastModified = commit.Date;
+
+            if (authorMap.TryGetValue(commit.Author, out var stats))
+            {
+                var newFirst = commit.Date < stats.first ? commit.Date : stats.first;
+                var newLast = commit.Date > stats.last ? commit.Date : stats.last;
+                authorMap[commit.Author] = (newFirst, newLast, stats.count + 1);
+            }
+            else
+            {
+                authorMap[commit.Author] = (commit.Date, commit.Date, 1);
+            }
+
+            hashes.Add(commit.Hash);
+
+            if (commit.Refs != null)
+            {
+                var refs = commit.Refs.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                foreach (var r in refs)
+                {
+                    if (r.StartsWith("tag:"))
+                    {
+                        tags.Add(r[4..].Trim());
+                    }
+                }
+            }
+        }
+
+        var authors = authorMap.Select(m => new AuthorMetadata(m.Key, m.Value.first, m.Value.last, m.Value.count)).ToArray();
+        return new FileMetadata(created, lastModified, authors, [.. hashes], [.. tags]);
+    }
+
+    public FileMetadata ParseSingleFileLog(string output)
+    {
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (lines.Length == 0)
+        {
+            return new FileMetadata(DateTimeOffset.MinValue, DateTimeOffset.MinValue, [], [], []);
+        }
+
+        var history = new List<(string Author, DateTimeOffset Date, string Hash, string? Refs)>();
+
+        foreach (var line in lines)
+        {
+            var parts = line.Split('|');
+            if (parts.Length < 2) continue;
+
+            var authorName = parts[0];
+            if (!DateTimeOffset.TryParse(parts[1], out var commitDate)) continue;
+
+            var hash = parts.Length >= 3 ? parts[2] : "";
+            var refs = parts.Length >= 4 && !string.IsNullOrWhiteSpace(parts[3]) ? parts[3] : null;
+
+            history.Add((authorName, commitDate, hash, refs));
+        }
+
+        return history.Count == 0
+            ? new FileMetadata(DateTimeOffset.MinValue, DateTimeOffset.MinValue, [], [], [])
+            : BuildFileMetadata(history);
+    }
+}

--- a/src/CodeToNeo4j/VersionControl/GitMetadataCache.cs
+++ b/src/CodeToNeo4j/VersionControl/GitMetadataCache.cs
@@ -1,0 +1,17 @@
+namespace CodeToNeo4j.VersionControl;
+
+public class GitMetadataCache : IGitMetadataCache
+{
+    public bool TryGet(string filePath, out FileMetadata metadata) =>
+        _cache.TryGetValue(filePath, out metadata!);
+
+    public void Set(string filePath, FileMetadata metadata) =>
+        _cache[filePath] = metadata;
+
+    public void Clear() =>
+        _cache.Clear();
+
+    public int Count => _cache.Count;
+
+    private readonly Dictionary<string, FileMetadata> _cache = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/CodeToNeo4j/VersionControl/GitService.cs
+++ b/src/CodeToNeo4j/VersionControl/GitService.cs
@@ -8,6 +8,8 @@ namespace CodeToNeo4j.VersionControl;
 public class GitService(
     IFileService fileService,
     IFileSystem fileSystem,
+    IGitLogParser logParser,
+    IGitMetadataCache metadataCache,
     ILogger<GitService> logger) : IVersionControlService
 {
     public async Task LoadMetadata(string workingDirectory, IEnumerable<string> includeExtensions)
@@ -16,7 +18,7 @@ public class GitService(
         var includedExtensionsSet = includeExtensions.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         logger.LogInformation("Pre-fetching git metadata for all files in the repository...");
-        _metadataCache.Clear();
+        metadataCache.Clear();
 
         var psi = new ProcessStartInfo
         {
@@ -30,7 +32,6 @@ public class GitService(
 
         using var p = Process.Start(psi) ?? throw new Exception("Failed to start git log for metadata pre-fetch.");
 
-        // Temporary data structure for raw history
         var fileHistory = new Dictionary<string, List<(string Author, DateTimeOffset Date, string Hash, string? Refs)>>(StringComparer.OrdinalIgnoreCase);
 
         string? currentAuthor = null;
@@ -59,7 +60,6 @@ public class GitService(
                 continue;
             }
 
-            // This is a file name
             var relPath = line.Trim();
             if (!includedExtensionsSet.Any(ext => relPath.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
             {
@@ -80,51 +80,11 @@ public class GitService(
 
         foreach (var kvp in fileHistory)
         {
-            var filePath = kvp.Key;
-            var history = kvp.Value;
-
-            var authorMap = new Dictionary<string, (DateTimeOffset first, DateTimeOffset last, int count)>();
-            var created = DateTimeOffset.MaxValue;
-            var lastModified = DateTimeOffset.MinValue;
-            var hashes = new List<string>();
-            var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var commit in history)
-            {
-                if (commit.Date < created) created = commit.Date;
-                if (commit.Date > lastModified) lastModified = commit.Date;
-
-                if (authorMap.TryGetValue(commit.Author, out var stats))
-                {
-                    var newFirst = commit.Date < stats.first ? commit.Date : stats.first;
-                    var newLast = commit.Date > stats.last ? commit.Date : stats.last;
-                    authorMap[commit.Author] = (newFirst, newLast, stats.count + 1);
-                }
-                else
-                {
-                    authorMap[commit.Author] = (commit.Date, commit.Date, 1);
-                }
-
-                hashes.Add(commit.Hash);
-
-                if (commit.Refs != null)
-                {
-                    var refs = commit.Refs.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                    foreach (var r in refs)
-                    {
-                        if (r.StartsWith("tag:"))
-                        {
-                            tags.Add(r[4..].Trim());
-                        }
-                    }
-                }
-            }
-
-            var authors = authorMap.Select(m => new AuthorMetadata(m.Key, m.Value.first, m.Value.last, m.Value.count)).ToArray();
-            _metadataCache[filePath] = new FileMetadata(created, lastModified, authors, [.. hashes], [.. tags]);
+            var metadata = logParser.BuildFileMetadata(kvp.Value);
+            metadataCache.Set(kvp.Key, metadata);
         }
 
-        logger.LogInformation("Loaded git metadata for {Count} files.", _metadataCache.Count);
+        logger.LogInformation("Loaded git metadata for {Count} files.", metadataCache.Count);
     }
 
     public async Task<DiffResult> GetChangedFiles(string diffBase, string workingDirectory, IEnumerable<string> includedExtensions)
@@ -239,12 +199,12 @@ public class GitService(
 
         if (p.ExitCode != 0) return [];
 
-        return ParseCommits(output, repoRoot);
+        return logParser.ParseCommits(output, repoRoot);
     }
 
     public async Task<FileMetadata> GetFileMetadata(string filePath, string workingDirectory)
     {
-        if (_metadataCache.TryGetValue(filePath, out var cached))
+        if (metadataCache.TryGet(filePath, out var cached))
         {
             return cached;
         }
@@ -273,118 +233,10 @@ public class GitService(
             return new FileMetadata(DateTimeOffset.MinValue, DateTimeOffset.MinValue, [], [], []);
         }
 
-        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (lines.Length == 0)
-        {
-            return new FileMetadata(DateTimeOffset.MinValue, DateTimeOffset.MinValue, [], [], []);
-        }
-
-        var authorMap = new Dictionary<string, (DateTimeOffset first, DateTimeOffset last, int count)>();
-        var created = DateTimeOffset.MaxValue;
-        var lastModified = DateTimeOffset.MinValue;
-        var commits = new List<string>();
-        var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var line in lines)
-        {
-            var parts = line.Split('|');
-            if (parts.Length < 2) continue;
-
-            var authorName = parts[0];
-            if (!DateTimeOffset.TryParse(parts[1], out var commitDate)) continue;
-
-            if (commitDate < created) created = commitDate;
-            if (commitDate > lastModified) lastModified = commitDate;
-
-            if (authorMap.TryGetValue(authorName, out var stats))
-            {
-                var newFirst = commitDate < stats.first ? commitDate : stats.first;
-                var newLast = commitDate > stats.last ? commitDate : stats.last;
-                authorMap[authorName] = (newFirst, newLast, stats.count + 1);
-            }
-            else
-            {
-                authorMap[authorName] = (commitDate, commitDate, 1);
-            }
-
-            if (parts.Length >= 3)
-            {
-                commits.Add(parts[2]);
-            }
-
-            if (parts.Length >= 4 && !string.IsNullOrWhiteSpace(parts[3]))
-            {
-                var refs = parts[3].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                foreach (var r in refs)
-                {
-                    if (r.StartsWith("tag:"))
-                    {
-                        tags.Add(r[4..].Trim());
-                    }
-                }
-            }
-        }
-
-        var authors = authorMap.Select(kvp => new AuthorMetadata(kvp.Key, kvp.Value.first, kvp.Value.last, kvp.Value.count)).ToArray();
-
-        var result = new FileMetadata(created, lastModified, authors, [.. commits], [.. tags]);
-        _metadataCache[filePath] = result;
+        var result = logParser.ParseSingleFileLog(output);
+        metadataCache.Set(filePath, result);
         return result;
     }
-
-    internal IEnumerable<CommitMetadata> ParseCommits(string output, string repoRoot)
-    {
-        var commits = new List<CommitMetadata>();
-        var lines = output.Split('\n', StringSplitOptions.TrimEntries);
-        CommitMetadata? currentCommit = null;
-        var changedFiles = new List<FileStatus>();
-
-        foreach (var line in lines)
-        {
-            if (string.IsNullOrWhiteSpace(line)) continue;
-
-            if (line.StartsWith("COMMIT|"))
-            {
-                if (currentCommit != null)
-                {
-                    commits.Add(currentCommit with { ChangedFiles = [.. changedFiles] });
-                    changedFiles = [];
-                }
-
-                var headerParts = line["COMMIT|".Length..].Split("|#|", 5, StringSplitOptions.None);
-                if (headerParts.Length >= 5)
-                {
-                    if (DateTimeOffset.TryParse(headerParts[3], out var date))
-                    {
-                        currentCommit = new CommitMetadata(headerParts[0], headerParts[1], headerParts[2], date, headerParts[4], []);
-                    }
-                }
-            }
-            else
-            {
-                if (currentCommit != null)
-                {
-                    var fileParts = line.Split('\t', StringSplitOptions.RemoveEmptyEntries);
-                    if (fileParts.Length >= 2)
-                    {
-                        var status = fileParts[0];
-                        var relPath = fileParts[1];
-                        var fullPath = fileService.NormalizePath(fileSystem.Path.Combine(repoRoot, relPath));
-                        changedFiles.Add(new FileStatus(fullPath, status.StartsWith('D')));
-                    }
-                }
-            }
-        }
-
-        if (currentCommit != null)
-        {
-            commits.Add(currentCommit with { ChangedFiles = [.. changedFiles] });
-        }
-
-        return commits;
-    }
-
-    private readonly Dictionary<string, FileMetadata> _metadataCache = new(StringComparer.OrdinalIgnoreCase);
 
     private static string GetRange(string diffBase) => diffBase.Contains("..") ? diffBase : $"{diffBase}...HEAD";
 

--- a/src/CodeToNeo4j/VersionControl/IGitLogParser.cs
+++ b/src/CodeToNeo4j/VersionControl/IGitLogParser.cs
@@ -1,0 +1,11 @@
+namespace CodeToNeo4j.VersionControl;
+
+public interface IGitLogParser
+{
+    IEnumerable<CommitMetadata> ParseCommits(string output, string repoRoot);
+
+    FileMetadata BuildFileMetadata(
+        IList<(string Author, DateTimeOffset Date, string Hash, string? Refs)> history);
+
+    FileMetadata ParseSingleFileLog(string output);
+}

--- a/src/CodeToNeo4j/VersionControl/IGitMetadataCache.cs
+++ b/src/CodeToNeo4j/VersionControl/IGitMetadataCache.cs
@@ -1,0 +1,9 @@
+namespace CodeToNeo4j.VersionControl;
+
+public interface IGitMetadataCache
+{
+    bool TryGet(string filePath, out FileMetadata metadata);
+    void Set(string filePath, FileMetadata metadata);
+    void Clear();
+    int Count { get; }
+}

--- a/tests/CodeToNeo4j.Tests/FileHandlers/AccessibilityFilterTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/AccessibilityFilterTests.cs
@@ -1,0 +1,88 @@
+using CodeToNeo4j.FileHandlers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Shouldly;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.FileHandlers;
+
+public class AccessibilityFilterTests
+{
+    [Theory]
+    [InlineData("public int Foo { get; set; }", Accessibility.Public, false)]
+    [InlineData("private int Foo { get; set; }", Accessibility.Public, true)]
+    [InlineData("internal int Foo { get; set; }", Accessibility.Public, true)]
+    [InlineData("protected int Foo { get; set; }", Accessibility.Public, true)]
+    [InlineData("private int Foo { get; set; }", Accessibility.Private, false)]
+    public void GivenMemberWithAccessibility_WhenIsAccessibilityBelowMinimumCalled_ThenReturnsExpectedResult(
+        string memberDeclaration, Accessibility minAccessibility, bool expectedResult)
+    {
+        // Arrange
+        var code = $"public class TestClass {{ {memberDeclaration} }}";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+        var classDecl = root.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax>().First();
+        var memberNode = classDecl.Members.First();
+        var symbol = model.GetDeclaredSymbol(memberNode)!;
+
+        // Act
+        var result = AccessibilityFilter.IsAccessibilityBelowMinimum(symbol, minAccessibility);
+
+        // Assert
+        result.ShouldBe(expectedResult);
+    }
+
+    [Fact]
+    public void GivenExplicitInterfaceImplementation_WhenIsAccessibilityBelowMinimumCalled_ThenReturnsFalse()
+    {
+        // Arrange
+        var code = @"
+            public interface IFoo { void Bar(); }
+            public class TestClass : IFoo { void IFoo.Bar() {} }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+        var classDecl = root.DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax>().First();
+        var methodNode = classDecl.Members.First();
+        var symbol = model.GetDeclaredSymbol(methodNode)!;
+
+        // Act — explicit interface impl has Private accessibility, but should NOT be filtered
+        var result = AccessibilityFilter.IsAccessibilityBelowMinimum(symbol, Accessibility.Public);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("public void Foo() {}", false)]
+    [InlineData("public int Prop { get; set; }", false)]
+    public void GivenNonExplicitInterfaceImpl_WhenIsExplicitInterfaceImplementationCalled_ThenReturnsFalse(
+        string memberDeclaration, bool expected)
+    {
+        // Arrange
+        var code = $"public class TestClass {{ {memberDeclaration} }}";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+        var classDecl = root.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax>().First();
+        var memberNode = classDecl.Members.First();
+        var symbol = model.GetDeclaredSymbol(memberNode)!;
+
+        // Act
+        var result = AccessibilityFilter.IsExplicitInterfaceImplementation(symbol);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+}

--- a/tests/CodeToNeo4j.Tests/FileHandlers/CSharpHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/CSharpHandlerTests.cs
@@ -25,7 +25,8 @@ public class CSharpHandlerTests
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -78,7 +79,8 @@ public class Foo : IBar
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -122,7 +124,8 @@ public class Foo : IBar
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -175,7 +178,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -226,7 +230,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -277,7 +282,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -328,7 +334,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -377,7 +384,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -429,7 +437,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -485,7 +494,8 @@ public class OrderService
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"
@@ -536,7 +546,8 @@ public class Factory
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         var code = @"

--- a/tests/CodeToNeo4j.Tests/FileHandlers/CSharpUsingDependencyTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/CSharpUsingDependencyTests.cs
@@ -18,7 +18,8 @@ public class CSharpUsingDependencyTests
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         // We use Microsoft.CodeAnalysis as an external dependency
@@ -65,7 +66,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         // We use Microsoft.CodeAnalysis.CSharp.SyntaxKind as a static using
@@ -113,7 +115,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         // We use Microsoft.CodeAnalysis as a global using
@@ -160,7 +163,8 @@ public class Foo
         // Arrange
         var fileSystem = A.Fake<IFileSystem>();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new CSharpHandler(symbolProcessor, fileSystem);
 
         // File 1 has the global using

--- a/tests/CodeToNeo4j.Tests/FileHandlers/MemberDependencyExtractorTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/MemberDependencyExtractorTests.cs
@@ -1,0 +1,199 @@
+using CodeToNeo4j.FileHandlers;
+using CodeToNeo4j.Graph;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Shouldly;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.FileHandlers;
+
+public class MemberDependencyExtractorTests
+{
+    [Fact]
+    public void GivenMethodWithParameter_WhenExtractMemberDependenciesCalled_ThenAddsDependsOnForParameterType()
+    {
+        // Arrange
+        var code = @"
+            public class Dep {}
+            public class TestClass {
+                public void Foo(Dep d) {}
+            }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+
+        var classDecl = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .First(c => c.Identifier.Text == "TestClass");
+        var methodNode = classDecl.Members.OfType<MethodDeclarationSyntax>().First();
+        var methodSymbol = model.GetDeclaredSymbol(methodNode)!;
+
+        var symbolMapper = new SymbolMapper();
+        var sut = new MemberDependencyExtractor(symbolMapper);
+        var relBuffer = new List<Relationship>();
+
+        var typeRec = new Symbol("test:TestClass", "TestClass", "Class", "TestClass", "TestClass", "Public", "file.cs", "file.cs", 1, 5, null, null, null);
+        var memberRec = new Symbol("test:TestClass.Foo", "Foo", "Method", "TestClass", "TestClass.Foo(Dep)", "Public", "file.cs", "file.cs", 3, 3, null, null, null);
+
+        // Act
+        sut.ExtractMemberDependencies(methodSymbol, methodNode, model, "test", relBuffer, typeRec, memberRec);
+
+        // Assert
+        relBuffer.ShouldContain(r => r.RelType == "DEPENDS_ON" && r.FromKey == typeRec.Key);
+    }
+
+    [Fact]
+    public void GivenMethodWithInvocation_WhenExtractMemberDependenciesCalled_ThenAddsInvokesRelationship()
+    {
+        // Arrange
+        var code = @"
+            public class Helper { public static void DoWork() {} }
+            public class TestClass {
+                public void Foo() { Helper.DoWork(); }
+            }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+
+        var classDecl = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .First(c => c.Identifier.Text == "TestClass");
+        var methodNode = classDecl.Members.OfType<MethodDeclarationSyntax>().First();
+        var methodSymbol = model.GetDeclaredSymbol(methodNode)!;
+
+        var symbolMapper = new SymbolMapper();
+        var sut = new MemberDependencyExtractor(symbolMapper);
+        var relBuffer = new List<Relationship>();
+
+        var typeRec = new Symbol("test:TestClass", "TestClass", "Class", "TestClass", "TestClass", "Public", "file.cs", "file.cs", 1, 5, null, null, null);
+        var memberRec = new Symbol("test:TestClass.Foo", "Foo", "Method", "TestClass", "TestClass.Foo()", "Public", "file.cs", "file.cs", 3, 3, null, null, null);
+
+        // Act
+        sut.ExtractMemberDependencies(methodSymbol, methodNode, model, "test", relBuffer, typeRec, memberRec);
+
+        // Assert
+        relBuffer.ShouldContain(r => r.RelType == "INVOKES" && r.FromKey == memberRec.Key);
+    }
+
+    [Fact]
+    public void GivenPropertyMember_WhenExtractMemberDependenciesCalled_ThenAddsDependsOnForPropertyType()
+    {
+        // Arrange
+        var code = @"
+            public class Dep {}
+            public class TestClass {
+                public Dep MyProp { get; set; }
+            }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+
+        var classDecl = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .First(c => c.Identifier.Text == "TestClass");
+        var propNode = classDecl.Members.OfType<PropertyDeclarationSyntax>().First();
+        var propSymbol = model.GetDeclaredSymbol(propNode)!;
+
+        var symbolMapper = new SymbolMapper();
+        var sut = new MemberDependencyExtractor(symbolMapper);
+        var relBuffer = new List<Relationship>();
+
+        var typeRec = new Symbol("test:TestClass", "TestClass", "Class", "TestClass", "TestClass", "Public", "file.cs", "file.cs", 1, 5, null, null, null);
+        var memberRec = new Symbol("test:TestClass.MyProp", "MyProp", "Property", "TestClass", "TestClass.MyProp", "Public", "file.cs", "file.cs", 3, 3, null, null, null);
+
+        // Act
+        sut.ExtractMemberDependencies(propSymbol, propNode, model, "test", relBuffer, typeRec, memberRec);
+
+        // Assert
+        relBuffer.ShouldContain(r => r.RelType == "DEPENDS_ON" && r.FromKey == typeRec.Key);
+    }
+
+    [Fact]
+    public void GivenFieldMember_WhenExtractMemberDependenciesCalled_ThenAddsDependsOnForFieldType()
+    {
+        // Arrange
+        var code = @"
+            public class Dep {}
+            public class TestClass {
+                public Dep _field;
+            }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+
+        var classDecl = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .First(c => c.Identifier.Text == "TestClass");
+        var fieldNode = classDecl.Members.OfType<FieldDeclarationSyntax>().First();
+        var variableNode = fieldNode.Declaration.Variables.First();
+        var fieldSymbol = model.GetDeclaredSymbol(variableNode)!;
+
+        var symbolMapper = new SymbolMapper();
+        var sut = new MemberDependencyExtractor(symbolMapper);
+        var relBuffer = new List<Relationship>();
+
+        var typeRec = new Symbol("test:TestClass", "TestClass", "Class", "TestClass", "TestClass", "Public", "file.cs", "file.cs", 1, 5, null, null, null);
+        var memberRec = new Symbol("test:TestClass._field", "_field", "Field", "TestClass", "TestClass._field", "Public", "file.cs", "file.cs", 3, 3, null, null, null);
+
+        // Act
+        sut.ExtractMemberDependencies(fieldSymbol, variableNode, model, "test", relBuffer, typeRec, memberRec);
+
+        // Assert
+        relBuffer.ShouldContain(r => r.RelType == "DEPENDS_ON" && r.FromKey == typeRec.Key);
+    }
+
+    [Fact]
+    public void GivenExternalNamespaceSymbol_WhenAddDependsOnIfExternalCalled_ThenAddsRelationship()
+    {
+        // Arrange
+        var code = "using System; public class TestClass {}";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+        var usingDirective = root.DescendantNodes().OfType<UsingDirectiveSyntax>().First();
+        var usingSymbol = model.GetSymbolInfo(usingDirective.Name!).Symbol;
+
+        var symbolMapper = new SymbolMapper();
+        var sut = new MemberDependencyExtractor(symbolMapper);
+        var relBuffer = new List<Relationship>();
+
+        // Act
+        sut.AddDependsOnIfExternal(usingSymbol, compilation.Assembly, "test", "file.cs", relBuffer);
+
+        // Assert
+        relBuffer.ShouldContain(r => r.RelType == "DEPENDS_ON" && r.FromKey == "file.cs");
+    }
+
+    [Fact]
+    public void GivenNullSymbol_WhenAddDependsOnIfExternalCalled_ThenNoRelationshipAdded()
+    {
+        // Arrange
+        var code = "public class TestClass {}";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        var symbolMapper = new SymbolMapper();
+        var sut = new MemberDependencyExtractor(symbolMapper);
+        var relBuffer = new List<Relationship>();
+
+        // Act
+        sut.AddDependsOnIfExternal(null, compilation.Assembly, "test", "file.cs", relBuffer);
+
+        // Assert
+        relBuffer.ShouldBeEmpty();
+    }
+}

--- a/tests/CodeToNeo4j.Tests/FileHandlers/RazorHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/RazorHandlerTests.cs
@@ -15,7 +15,8 @@ public class RazorHandlerTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new RazorHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"@namespace MyProject.Pages
 <h1>Hello</h1>";
@@ -46,7 +47,8 @@ public class RazorHandlerTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new RazorHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 @using System.Text

--- a/tests/CodeToNeo4j.Tests/FileHandlers/RazorRoslynTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/RazorRoslynTests.cs
@@ -17,7 +17,8 @@ public class RazorRoslynTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new RazorHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         
         var razorFilePath = "Pages/Index.razor";

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlHandlerTests.cs
@@ -15,7 +15,8 @@ public class XamlHandlerTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 <Window x:Class=""MyApp.MainWindow""

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlNamespaceTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlNamespaceTests.cs
@@ -17,7 +17,8 @@ public class XamlNamespaceTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = $@"
 <Window x:Class=""MyApp.MainWindow""
@@ -55,7 +56,8 @@ public class XamlNamespaceTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 <ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
@@ -92,7 +94,8 @@ public class XamlNamespaceTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 <ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
@@ -129,7 +132,8 @@ public class XamlNamespaceTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         var content = @"
 <Window xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"">

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XamlRoslynTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XamlRoslynTests.cs
@@ -17,7 +17,8 @@ public class XamlRoslynTests
         // Arrange
         var fileSystem = new MockFileSystem();
         var symbolMapper = new SymbolMapper();
-        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper);
+        var dependencyExtractor = new MemberDependencyExtractor(symbolMapper);
+        var symbolProcessor = new RoslynSymbolProcessor(symbolMapper, dependencyExtractor);
         var sut = new XamlHandler(symbolProcessor, fileSystem, new TextSymbolMapper());
         
         var xamlFilePath = "MainWindow.xaml";

--- a/tests/CodeToNeo4j.Tests/Solution/CommitIngestionServiceTests.cs
+++ b/tests/CodeToNeo4j.Tests/Solution/CommitIngestionServiceTests.cs
@@ -1,0 +1,75 @@
+#pragma warning disable CS8600, CS8604 // FakeItEasy argument matchers produce null for non-nullable types
+using CodeToNeo4j.Graph;
+using CodeToNeo4j.Solution;
+using CodeToNeo4j.VersionControl;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.Solution;
+
+public class CommitIngestionServiceTests
+{
+    [Fact]
+    public async Task GivenZeroCommits_WhenIngestCommitsCalled_ThenDoesNotCallUpsert()
+    {
+        // Arrange
+        var vcs = A.Fake<IVersionControlService>();
+        var graph = A.Fake<IGraphService>();
+        var logger = A.Fake<ILogger<CommitIngestionService>>();
+        A.CallTo(() => vcs.GetCommitCount("main", "/repo")).Returns(0);
+        var sut = new CommitIngestionService(vcs, graph, logger);
+
+        // Act
+        await sut.IngestCommits("main", "/repo", "key", "db", 100);
+
+        // Assert
+        A.CallTo(() => graph.UpsertCommits(A<string>._, A<string>._, A<IEnumerable<CommitMetadata>>._, A<string>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task GivenCommitsExist_WhenIngestCommitsCalled_ThenCallsGetCommitBatchAndUpsert()
+    {
+        // Arrange
+        var vcs = A.Fake<IVersionControlService>();
+        var graph = A.Fake<IGraphService>();
+        var logger = A.Fake<ILogger<CommitIngestionService>>();
+        A.CallTo(() => vcs.GetCommitCount("main", "/repo")).Returns(5);
+        A.CallTo(() => vcs.GetCommitBatch("main", "/repo", 100, 0))
+            .Returns(new List<CommitMetadata>
+            {
+                new("h1", "Author", "a@b.com", DateTimeOffset.Now, "msg", [])
+            });
+        var sut = new CommitIngestionService(vcs, graph, logger);
+
+        // Act
+        await sut.IngestCommits("main", "/repo", "key", "db", 100);
+
+        // Assert
+        A.CallTo(() => vcs.GetCommitBatch("main", "/repo", 100, 0)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => graph.UpsertCommits("key", "/repo", A<IEnumerable<CommitMetadata>>._, "db"))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task GivenMoreCommitsThanBatchSize_WhenIngestCommitsCalled_ThenCallsMultipleBatches()
+    {
+        // Arrange
+        var vcs = A.Fake<IVersionControlService>();
+        var graph = A.Fake<IGraphService>();
+        var logger = A.Fake<ILogger<CommitIngestionService>>();
+        A.CallTo(() => vcs.GetCommitCount("main", "/repo")).Returns(250);
+        A.CallTo(() => vcs.GetCommitBatch(A<string>._, A<string>._, A<int>._, A<int>._))
+            .Returns(new List<CommitMetadata>());
+        var sut = new CommitIngestionService(vcs, graph, logger);
+
+        // Act
+        await sut.IngestCommits("main", "/repo", "key", "db", 100);
+
+        // Assert — 250 commits / batch 100 = 3 batches (0, 100, 200)
+        A.CallTo(() => vcs.GetCommitBatch("main", "/repo", 100, A<int>._))
+            .MustHaveHappened(3, Times.Exactly);
+    }
+}
+#pragma warning restore CS8600, CS8604

--- a/tests/CodeToNeo4j.Tests/VersionControl/GitLogParserTests.cs
+++ b/tests/CodeToNeo4j.Tests/VersionControl/GitLogParserTests.cs
@@ -1,0 +1,134 @@
+using CodeToNeo4j.FileSystem;
+using CodeToNeo4j.VersionControl;
+using FakeItEasy;
+using System.IO.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.VersionControl;
+
+public class GitLogParserTests
+{
+    [Theory]
+    [InlineData("COMMIT|hash1|#|Author|#|a@b.com|#|2026-01-01T00:00:00Z|#|msg\nM\tfile.cs", 1)]
+    [InlineData("", 0)]
+    [InlineData("   \n  \n  ", 0)]
+    public void GivenGitLogOutput_WhenParseCommitsCalled_ThenReturnsExpectedCount(string output, int expectedCount)
+    {
+        // Arrange
+        var fileService = A.Fake<IFileService>();
+        var fileSystem = new System.IO.Abstractions.FileSystem();
+        A.CallTo(() => fileService.NormalizePath(A<string>._)).ReturnsLazily((string s) => s.Replace('\\', '/'));
+        var sut = new GitLogParser(fileService, fileSystem);
+
+        // Act
+        var result = sut.ParseCommits(output, "/repo").ToList();
+
+        // Assert
+        result.Count.ShouldBe(expectedCount);
+    }
+
+    [Fact]
+    public void GivenDeletedFile_WhenParseCommitsCalled_ThenFileStatusIsDeleted()
+    {
+        // Arrange
+        var fileService = A.Fake<IFileService>();
+        var fileSystem = new System.IO.Abstractions.FileSystem();
+        A.CallTo(() => fileService.NormalizePath(A<string>._)).ReturnsLazily((string s) => s.Replace('\\', '/'));
+        var sut = new GitLogParser(fileService, fileSystem);
+        var output = "COMMIT|h1|#|Author|#|a@b.com|#|2026-01-01T00:00:00Z|#|delete file\nD\tremoved.cs";
+
+        // Act
+        var result = sut.ParseCommits(output, "/repo").ToList();
+
+        // Assert
+        result[0].ChangedFiles.ShouldContain(f => f.IsDeleted && f.Path == "/repo/removed.cs");
+    }
+
+    [Fact]
+    public void GivenSingleCommitHistory_WhenBuildFileMetadataCalled_ThenReturnsCorrectMetadata()
+    {
+        // Arrange
+        var fileService = A.Fake<IFileService>();
+        var fileSystem = new System.IO.Abstractions.FileSystem();
+        var sut = new GitLogParser(fileService, fileSystem);
+        var date = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var history = new List<(string Author, DateTimeOffset Date, string Hash, string? Refs)>
+        {
+            ("Author One <a@b.com>", date, "abc123", null)
+        };
+
+        // Act
+        var result = sut.BuildFileMetadata(history);
+
+        // Assert
+        result.Created.ShouldBe(date);
+        result.LastModified.ShouldBe(date);
+        result.Authors.Count().ShouldBe(1);
+        result.Authors.First().Name.ShouldBe("Author One <a@b.com>");
+        result.Authors.First().CommitCount.ShouldBe(1);
+        result.Commits.ShouldContain("abc123");
+    }
+
+    [Fact]
+    public void GivenMultipleCommitsWithTags_WhenBuildFileMetadataCalled_ThenExtractsTags()
+    {
+        // Arrange
+        var fileService = A.Fake<IFileService>();
+        var fileSystem = new System.IO.Abstractions.FileSystem();
+        var sut = new GitLogParser(fileService, fileSystem);
+        var date1 = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var date2 = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var history = new List<(string Author, DateTimeOffset Date, string Hash, string? Refs)>
+        {
+            ("Author", date1, "h1", "tag: v1.0"),
+            ("Author", date2, "h2", "tag: v2.0, HEAD -> main")
+        };
+
+        // Act
+        var result = sut.BuildFileMetadata(history);
+
+        // Assert
+        result.Created.ShouldBe(date1);
+        result.LastModified.ShouldBe(date2);
+        result.Tags.ShouldContain("v1.0");
+        result.Tags.ShouldContain("v2.0");
+        result.Authors.First().CommitCount.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData("   ", 0)]
+    public void GivenEmptyOutput_WhenParseSingleFileLogCalled_ThenReturnsEmptyMetadata(string output, int expectedAuthorCount)
+    {
+        // Arrange
+        var fileService = A.Fake<IFileService>();
+        var fileSystem = new System.IO.Abstractions.FileSystem();
+        var sut = new GitLogParser(fileService, fileSystem);
+
+        // Act
+        var result = sut.ParseSingleFileLog(output);
+
+        // Assert
+        result.Authors.Count().ShouldBe(expectedAuthorCount);
+        result.Created.ShouldBe(DateTimeOffset.MinValue);
+    }
+
+    [Fact]
+    public void GivenValidSingleFileLog_WhenParseSingleFileLogCalled_ThenReturnsMetadata()
+    {
+        // Arrange
+        var fileService = A.Fake<IFileService>();
+        var fileSystem = new System.IO.Abstractions.FileSystem();
+        var sut = new GitLogParser(fileService, fileSystem);
+        var output = "Author One <a@b.com>|2026-03-01T12:00:00Z|abc123|tag: v1.0\nAuthor Two <c@d.com>|2026-02-01T12:00:00Z|def456|";
+
+        // Act
+        var result = sut.ParseSingleFileLog(output);
+
+        // Assert
+        result.Authors.Count().ShouldBe(2);
+        result.Commits.Count().ShouldBe(2);
+        result.Tags.ShouldContain("v1.0");
+    }
+}

--- a/tests/CodeToNeo4j.Tests/VersionControl/GitMetadataCacheTests.cs
+++ b/tests/CodeToNeo4j.Tests/VersionControl/GitMetadataCacheTests.cs
@@ -1,0 +1,81 @@
+using CodeToNeo4j.VersionControl;
+using Shouldly;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.VersionControl;
+
+public class GitMetadataCacheTests
+{
+    [Fact]
+    public void GivenEmptyCache_WhenTryGetCalled_ThenReturnsFalse()
+    {
+        // Arrange
+        var sut = new GitMetadataCache();
+
+        // Act
+        var found = sut.TryGet("/some/file.cs", out _);
+
+        // Assert
+        found.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenCachedEntry_WhenTryGetCalled_ThenReturnsTrueWithMetadata()
+    {
+        // Arrange
+        var sut = new GitMetadataCache();
+        var metadata = new FileMetadata(DateTimeOffset.Now, DateTimeOffset.Now, [], [], []);
+        sut.Set("/some/file.cs", metadata);
+
+        // Act
+        var found = sut.TryGet("/some/file.cs", out var result);
+
+        // Assert
+        found.ShouldBeTrue();
+        result.ShouldBe(metadata);
+    }
+
+    [Fact]
+    public void GivenCaseInsensitivePaths_WhenTryGetCalled_ThenMatchesRegardlessOfCase()
+    {
+        // Arrange
+        var sut = new GitMetadataCache();
+        var metadata = new FileMetadata(DateTimeOffset.Now, DateTimeOffset.Now, [], [], []);
+        sut.Set("/Some/FILE.cs", metadata);
+
+        // Act
+        var found = sut.TryGet("/some/file.cs", out var result);
+
+        // Assert
+        found.ShouldBeTrue();
+        result.ShouldBe(metadata);
+    }
+
+    [Fact]
+    public void GivenPopulatedCache_WhenClearCalled_ThenCacheIsEmpty()
+    {
+        // Arrange
+        var sut = new GitMetadataCache();
+        sut.Set("/a.cs", new FileMetadata(DateTimeOffset.Now, DateTimeOffset.Now, [], [], []));
+        sut.Set("/b.cs", new FileMetadata(DateTimeOffset.Now, DateTimeOffset.Now, [], [], []));
+
+        // Act
+        sut.Clear();
+
+        // Assert
+        sut.Count.ShouldBe(0);
+        sut.TryGet("/a.cs", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenMultipleEntries_WhenCountAccessed_ThenReturnsCorrectCount()
+    {
+        // Arrange
+        var sut = new GitMetadataCache();
+        sut.Set("/a.cs", new FileMetadata(DateTimeOffset.Now, DateTimeOffset.Now, [], [], []));
+        sut.Set("/b.cs", new FileMetadata(DateTimeOffset.Now, DateTimeOffset.Now, [], [], []));
+
+        // Act & Assert
+        sut.Count.ShouldBe(2);
+    }
+}

--- a/tests/CodeToNeo4j.Tests/VersionControl/GitServiceTests.cs
+++ b/tests/CodeToNeo4j.Tests/VersionControl/GitServiceTests.cs
@@ -1,7 +1,6 @@
 using CodeToNeo4j.FileSystem;
 using CodeToNeo4j.VersionControl;
 using FakeItEasy;
-using Microsoft.Extensions.Logging;
 using System.IO.Abstractions;
 using Shouldly;
 using Xunit;
@@ -14,10 +13,9 @@ public class GitServiceTests
     public void GivenValidGitLogOutput_WhenParseCommitsCalled_ThenReturnsExpectedCommits()
     {
         // Arrange
-        var logger = A.Fake<ILogger<GitService>>();
         var fileSystem = new System.IO.Abstractions.FileSystem();
         var fileService = A.Fake<IFileService>();
-        var sut = new GitService(fileService, fileSystem, logger);
+        var sut = new GitLogParser(fileService, fileSystem);
 
         var repoRoot = "/repo";
         var output = @"COMMIT|hash1|#|Author One|#|author1@example.com|#|2026-03-09T14:20:00Z|#|Commit Message One


### PR DESCRIPTION
## Summary

- Extract `AccessibilityFilter` and `MemberDependencyExtractor` from `RoslynSymbolProcessor` (498→230 lines)
- Extract `GitLogParser` and `GitMetadataCache` from `GitService` (414→200 lines)
- Extract `Neo4jSchemaService` and `Neo4jFlushService` from `Neo4jService` (342→130 lines)
- Extract `CommitIngestionService` from `SolutionProcessor` (275→230 lines)
- Register all new services in DI container
- Add 31 new unit tests for extracted classes (188→219 total)

## Issue

Resolves #58

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change