### PR TITLE
Fix invalid regex in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,11 @@
       "groupName": "Microsoft and System",
       "matchPackageNames": [
         "/^Microsoft\\./",
-        "/^System\\.(?!IO\\.Abstractions)/"
+        "/^System\\./"
+      ],
+      "excludePackageNames": [
+        "System.IO.Abstractions",
+        "System.IO.Abstractions.TestingHelpers"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Replace unsupported negative lookahead regex (`/^System\.(?!IO\.Abstractions)/`) in `matchPackageNames` with a simple `/^System\./` pattern
- Use `excludePackageNames` to keep `System.IO.Abstractions` and `System.IO.Abstractions.TestingHelpers` in their own dedicated group

## Issue

Resolves #80

## Checklist
- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change