### PR TITLE
Fix Renovate PR issue workflow to use label check

### DIFF
--- a/.github/workflows/renovate-pr-issue.yml
+++ b/.github/workflows/renovate-pr-issue.yml
@@ -2,7 +2,7 @@ name: Link Renovate PRs to Issues
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, labeled]
 
 permissions:
   contents: read
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   create-and-link-issue:
-    if: github.event.pull_request.user.login == 'renovate[bot]'
+    if: contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: self-hosted
     steps:
       - name: Create issue and update PR body
@@ -20,6 +20,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
+
+            // Skip if PR body already contains a Resolves reference
+            if (pr.body && /^Resolves #\d+/m.test(pr.body)) {
+              core.info(`PR #${pr.number} already has a Resolves reference. Skipping.`);
+              return;
+            }
 
             // Create a tracking issue for this Renovate PR
             const issue = await github.rest.issues.create({


### PR DESCRIPTION
## Summary
- Replace `github.event.pull_request.user.login == 'renovate[bot]'` with `contains(github.event.pull_request.labels.*.name, 'renovate')` — self-hosted Renovate uses a PAT so PRs are authored by the PAT owner, not `renovate[bot]`
- Add `labeled` event type so the workflow fires even if labels are applied after PR creation
- Add idempotency guard to skip PRs that already have a `Resolves #` reference, preventing duplicate issues on reopens

## Issue

Resolves #101

## Checklist
- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change