### PR TITLE
Add synchronize trigger to Renovate PR issue workflow

### DIFF
--- a/.github/workflows/renovate-pr-issue.yml
+++ b/.github/workflows/renovate-pr-issue.yml
@@ -2,7 +2,7 @@ name: Link Renovate PRs to Issues
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, labeled, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- When Renovate rebases or pushes new commits, it regenerates the PR body, wiping any previously added `Resolves #` reference
- The workflow now searches for an existing tracking issue (by matching `"Tracking issue for Renovate PR #N"` with the `renovate` label) before creating a new one
- On first PR open: creates a tracking issue and prepends `Resolves #<n>` to the body
- On subsequent pushes/rebases: finds the existing issue and re-adds the `Resolves #<n>` reference

## Issue

Resolves #99

## Checklist
- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change