### PR TITLE
Extract operator usage as INVOKES relationships

### DIFF
--- a/src/CodeToNeo4j/FileHandlers/MemberDependencyExtractor.cs
+++ b/src/CodeToNeo4j/FileHandlers/MemberDependencyExtractor.cs
@@ -1,5 +1,6 @@
 using CodeToNeo4j.Graph;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CodeToNeo4j.FileHandlers;
@@ -80,21 +81,81 @@ public class MemberDependencyExtractor(ISymbolMapper symbolMapper) : IMemberDepe
 
         var seenCallees = new HashSet<string>();
 
-        foreach (var invocation in body.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        foreach (var node in body.DescendantNodes())
         {
-            if (semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol calleeSymbol) continue;
-            var calleeKey = symbolMapper.BuildStableSymbolKey(repoKey, calleeSymbol);
-            if (seenCallees.Add(calleeKey))
-                relBuffer.Add(new Relationship(FromKey: callerRec.Key, ToKey: calleeKey, RelType: "INVOKES"));
-        }
+            switch (node)
+            {
+                // Method invocations
+                case InvocationExpressionSyntax invocation:
+                    if (semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol calleeSymbol)
+                        AddInvokes(calleeSymbol, callerRec, repoKey, relBuffer, seenCallees);
+                    break;
 
-        foreach (var objectCreation in body.DescendantNodes().OfType<BaseObjectCreationExpressionSyntax>())
-        {
-            if (semanticModel.GetSymbolInfo(objectCreation).Symbol is not IMethodSymbol ctorSymbol) continue;
-            var calleeKey = symbolMapper.BuildStableSymbolKey(repoKey, ctorSymbol);
-            if (seenCallees.Add(calleeKey))
-                relBuffer.Add(new Relationship(FromKey: callerRec.Key, ToKey: calleeKey, RelType: "INVOKES"));
+                // Constructor invocations
+                case BaseObjectCreationExpressionSyntax objectCreation:
+                    if (semanticModel.GetSymbolInfo(objectCreation).Symbol is IMethodSymbol ctorSymbol)
+                        AddInvokes(ctorSymbol, callerRec, repoKey, relBuffer, seenCallees);
+                    break;
+
+                // Binary operators (==, !=, >, <, >=, <=, |, &, ^) and 'as' expressions
+                case BinaryExpressionSyntax binary:
+                    if (semanticModel.GetSymbolInfo(binary).Symbol is IMethodSymbol binSymbol
+                        && binSymbol.MethodKind is MethodKind.UserDefinedOperator or MethodKind.Conversion)
+                        AddInvokes(binSymbol, callerRec, repoKey, relBuffer, seenCallees);
+                    break;
+
+                // Explicit cast expressions: (int)foo
+                case CastExpressionSyntax cast:
+                    if (semanticModel.GetSymbolInfo(cast).Symbol is IMethodSymbol { MethodKind: MethodKind.Conversion } convSymbol)
+                        AddInvokes(convSymbol, callerRec, repoKey, relBuffer, seenCallees);
+                    break;
+
+                // Unary prefix operators: !, ~, +, -, ++, --
+                case PrefixUnaryExpressionSyntax prefix:
+                    if (semanticModel.GetSymbolInfo(prefix).Symbol is IMethodSymbol { MethodKind: MethodKind.UserDefinedOperator } prefixOp)
+                        AddInvokes(prefixOp, callerRec, repoKey, relBuffer, seenCallees);
+                    break;
+
+                // Unary postfix operators: ++, --
+                case PostfixUnaryExpressionSyntax postfix:
+                    if (semanticModel.GetSymbolInfo(postfix).Symbol is IMethodSymbol { MethodKind: MethodKind.UserDefinedOperator } postfixOp)
+                        AddInvokes(postfixOp, callerRec, repoKey, relBuffer, seenCallees);
+                    break;
+            }
+
+            // Implicit conversions (assignments, arguments, return values, etc.)
+            if (node is ExpressionSyntax expr && IsImplicitConversionCandidate(expr))
+            {
+                var conversion = semanticModel.GetConversion(expr);
+                if (conversion.IsUserDefined && conversion.MethodSymbol is { MethodKind: MethodKind.Conversion } implicitSymbol)
+                    AddInvokes(implicitSymbol, callerRec, repoKey, relBuffer, seenCallees);
+            }
         }
+    }
+
+    private static bool IsImplicitConversionCandidate(ExpressionSyntax expr)
+    {
+        return expr.Parent switch
+        {
+            EqualsValueClauseSyntax => true,
+            AssignmentExpressionSyntax a => expr == a.Right,
+            ArgumentSyntax => true,
+            ReturnStatementSyntax => true,
+            ArrowExpressionClauseSyntax => true,
+            _ => false
+        };
+    }
+
+    private void AddInvokes(
+        IMethodSymbol calleeSymbol,
+        Symbol callerRec,
+        string? repoKey,
+        ICollection<Relationship> relBuffer,
+        HashSet<string> seenCallees)
+    {
+        var calleeKey = symbolMapper.BuildStableSymbolKey(repoKey, calleeSymbol);
+        if (seenCallees.Add(calleeKey))
+            relBuffer.Add(new Relationship(FromKey: callerRec.Key, ToKey: calleeKey, RelType: "INVOKES"));
     }
 
     private void ExtractMethodDependencies(

--- a/tests/CodeToNeo4j.Tests/FileHandlers/MemberDependencyExtractorTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/MemberDependencyExtractorTests.cs
@@ -196,4 +196,296 @@ public class MemberDependencyExtractorTests
         // Assert
         relBuffer.ShouldBeEmpty();
     }
+
+    [Theory]
+    [InlineData("==", "operator ==(Foo, Foo)")]
+    [InlineData("!=", "operator !=(Foo, Foo)")]
+    public void GivenEqualityOperatorUsage_WhenExtracted_ThenAddsInvokesRelationship(string op, string expectedFragment)
+    {
+        var code = $$"""
+            public class Foo {
+                public int Value;
+                public static bool operator ==(Foo a, Foo b) => a.Value == b.Value;
+                public static bool operator !=(Foo a, Foo b) => !(a == b);
+                public override bool Equals(object obj) => obj is Foo f && this == f;
+                public override int GetHashCode() => Value;
+            }
+            public class TestClass {
+                public void Use(Foo a, Foo b) { var r = a {{op}} b; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains(expectedFragment));
+    }
+
+    [Theory]
+    [InlineData(">", "operator >(Foo, Foo)")]
+    [InlineData("<", "operator <(Foo, Foo)")]
+    [InlineData(">=", "operator >=(Foo, Foo)")]
+    [InlineData("<=", "operator <=(Foo, Foo)")]
+    public void GivenComparisonOperatorUsage_WhenExtracted_ThenAddsInvokesRelationship(string op, string expectedFragment)
+    {
+        var code = $$"""
+            public class Foo {
+                public int Value;
+                public static bool operator >(Foo a, Foo b) => a.Value > b.Value;
+                public static bool operator <(Foo a, Foo b) => a.Value < b.Value;
+                public static bool operator >=(Foo a, Foo b) => a.Value >= b.Value;
+                public static bool operator <=(Foo a, Foo b) => a.Value <= b.Value;
+            }
+            public class TestClass {
+                public void Use(Foo a, Foo b) { var r = a {{op}} b; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains(expectedFragment));
+    }
+
+    [Theory]
+    [InlineData("|", "operator |(Foo, Foo)")]
+    [InlineData("&", "operator &(Foo, Foo)")]
+    [InlineData("^", "operator ^(Foo, Foo)")]
+    public void GivenBitwiseOperatorUsage_WhenExtracted_ThenAddsInvokesRelationship(string op, string expectedFragment)
+    {
+        var code = $$"""
+            public class Foo {
+                public int Value;
+                public static Foo operator |(Foo a, Foo b) => new Foo { Value = a.Value | b.Value };
+                public static Foo operator &(Foo a, Foo b) => new Foo { Value = a.Value & b.Value };
+                public static Foo operator ^(Foo a, Foo b) => new Foo { Value = a.Value ^ b.Value };
+            }
+            public class TestClass {
+                public void Use(Foo a, Foo b) { var r = a {{op}} b; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains(expectedFragment));
+    }
+
+    [Theory]
+    [InlineData("+", "operator +(Foo, Foo)")]
+    [InlineData("-", "operator -(Foo, Foo)")]
+    [InlineData("*", "operator *(Foo, Foo)")]
+    [InlineData("/", "operator /(Foo, Foo)")]
+    [InlineData("%", "operator %(Foo, Foo)")]
+    public void GivenArithmeticOperatorUsage_WhenExtracted_ThenAddsInvokesRelationship(string op, string expectedFragment)
+    {
+        var code = $$"""
+            public class Foo {
+                public int Value;
+                public static Foo operator +(Foo a, Foo b) => new Foo { Value = a.Value + b.Value };
+                public static Foo operator -(Foo a, Foo b) => new Foo { Value = a.Value - b.Value };
+                public static Foo operator *(Foo a, Foo b) => new Foo { Value = a.Value * b.Value };
+                public static Foo operator /(Foo a, Foo b) => new Foo { Value = a.Value / b.Value };
+                public static Foo operator %(Foo a, Foo b) => new Foo { Value = a.Value % b.Value };
+            }
+            public class TestClass {
+                public void Use(Foo a, Foo b) { var r = a {{op}} b; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains(expectedFragment));
+    }
+
+    [Theory]
+    [InlineData("<<", "operator <<(Foo, int)")]
+    [InlineData(">>", "operator >>(Foo, int)")]
+    public void GivenShiftOperatorUsage_WhenExtracted_ThenAddsInvokesRelationship(string op, string expectedFragment)
+    {
+        var code = $$"""
+            public class Foo {
+                public int Value;
+                public static Foo operator <<(Foo a, int b) => new Foo { Value = a.Value << b };
+                public static Foo operator >>(Foo a, int b) => new Foo { Value = a.Value >> b };
+            }
+            public class TestClass {
+                public void Use(Foo a) { var r = a {{op}} 2; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains(expectedFragment));
+    }
+
+    [Theory]
+    [InlineData("!", "operator !(Foo)")]
+    [InlineData("~", "operator ~(Foo)")]
+    public void GivenUnaryOperatorUsage_WhenExtracted_ThenAddsInvokesRelationship(string op, string expectedFragment)
+    {
+        var code = $$"""
+            public class Foo {
+                public int Value;
+                public static Foo operator !(Foo a) => new Foo { Value = a.Value == 0 ? 1 : 0 };
+                public static Foo operator ~(Foo a) => new Foo { Value = ~a.Value };
+            }
+            public class TestClass {
+                public void Use(Foo a) { var r = {{op}}a; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains(expectedFragment));
+    }
+
+    [Theory]
+    [InlineData("++", "operator ++(Foo)")]
+    [InlineData("--", "operator --(Foo)")]
+    public void GivenIncrementDecrementOperatorUsage_WhenExtracted_ThenAddsInvokesRelationship(string op, string expectedFragment)
+    {
+        var code = $$"""
+            public class Foo {
+                public int Value;
+                public static Foo operator ++(Foo a) => new Foo { Value = a.Value + 1 };
+                public static Foo operator --(Foo a) => new Foo { Value = a.Value - 1 };
+            }
+            public class TestClass {
+                public void Use(Foo a) { {{op}}a; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains(expectedFragment));
+    }
+
+    [Fact]
+    public void GivenExplicitCastOperatorUsage_WhenExtracted_ThenAddsInvokesRelationship()
+    {
+        var code = """
+            public class Foo {
+                public int Value;
+                public static explicit operator int(Foo a) => a.Value;
+            }
+            public class TestClass {
+                public void Use(Foo f) { var x = (int)f; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains("explicit operator int(Foo)"));
+    }
+
+    [Fact]
+    public void GivenImplicitConversionViaAssignment_WhenExtracted_ThenAddsInvokesRelationship()
+    {
+        var code = """
+            public class Foo {
+                public static implicit operator string(Foo a) => "foo";
+            }
+            public class TestClass {
+                public void Use() {
+                    Foo f = new Foo();
+                    string s = f;
+                }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains("implicit operator string(Foo)"));
+    }
+
+    [Fact]
+    public void GivenImplicitConversionViaVariableInitializer_WhenExtracted_ThenAddsInvokesRelationship()
+    {
+        var code = """
+            public class FooFixture {
+                public static implicit operator Foo(FooFixture a) => new Foo();
+            }
+            public class Foo {}
+            public class TestClass {
+                public void Use() {
+                    Foo f = new FooFixture();
+                }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldContain(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains("implicit operator Foo(FooFixture)"));
+    }
+
+    [Fact]
+    public void GivenBuiltInOperator_WhenExtracted_ThenDoesNotAddInvokesRelationship()
+    {
+        var code = """
+            public class TestClass {
+                public void Use() { var r = 1 + 2; var b = 1 == 2; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.ShouldNotContain(r => r.RelType == "INVOKES" && r.ToKey.Contains("operator"));
+    }
+
+    [Fact]
+    public void GivenDuplicateOperatorUsage_WhenExtracted_ThenAddsOnlyOneInvokesRelationship()
+    {
+        var code = """
+            public class Foo {
+                public int Value;
+                public static bool operator ==(Foo a, Foo b) => a.Value == b.Value;
+                public static bool operator !=(Foo a, Foo b) => !(a == b);
+                public override bool Equals(object obj) => obj is Foo f && this == f;
+                public override int GetHashCode() => Value;
+            }
+            public class TestClass {
+                public void Use(Foo a, Foo b) { var r1 = a == b; var r2 = a == b; }
+            }
+            """;
+
+        var relBuffer = ExtractRelationships(code, "TestClass", "Use");
+
+        relBuffer.Count(r =>
+            r.RelType == "INVOKES" && r.ToKey.Contains("operator ==(Foo, Foo)")).ShouldBe(1);
+    }
+
+    private static List<Relationship> ExtractRelationships(string code, string className, string methodName)
+    {
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+
+        var classDecl = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .First(c => c.Identifier.Text == className);
+        var methodNode = classDecl.Members.OfType<MethodDeclarationSyntax>()
+            .First(m => m.Identifier.Text == methodName);
+        var methodSymbol = model.GetDeclaredSymbol(methodNode)!;
+
+        var symbolMapper = new SymbolMapper();
+        var sut = new MemberDependencyExtractor(symbolMapper);
+        var relBuffer = new List<Relationship>();
+
+        var typeRec = new Symbol($"test:{className}", className, "Class", className, className, "Public", "file.cs", "file.cs", 1, 10, null, null, null);
+        var memberRec = new Symbol($"test:{className}.{methodName}", methodName, "Method", className, $"{className}.{methodName}()", "Public", "file.cs", "file.cs", 3, 3, null, null, null);
+
+        sut.ExtractMemberDependencies(methodSymbol, methodNode, model, "test", relBuffer, typeRec, memberRec);
+
+        return relBuffer;
+    }
 }


### PR DESCRIPTION
## Summary

- Extend `MemberDependencyExtractor.ExtractMethodExecutes` to detect user-defined operator invocations and emit `INVOKES` relationships
- Covers binary operators (`==`, `!=`, `>`, `<`, `>=`, `<=`, `|`, `&`, `^`, `+`, `-`, `*`, `/`, `%`, `<<`, `>>`), unary operators (`!`, `~`, `++`, `--`), explicit casts, `as` expressions, and implicit conversions
- Consolidates descendant-node traversal into a single pass for performance
- Adds 20+ new test cases covering all operator categories

## Issue

Resolves #133

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change