### PR TITLE
Move MAJOR and MINOR build numbers to GitHub repository variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ jobs:
   release:
     runs-on: self-hosted
     if: github.ref == 'refs/heads/main'
-    env:
-      MAJOR: 1
-      MINOR: 1
 
     steps:
     - uses: actions/checkout@v6
@@ -31,13 +28,13 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build --no-restore -c Release /p:Version=${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }}
+      run: dotnet build --no-restore -c Release /p:Version=${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
 
     - name: Test
       run: dotnet test --no-build -c Release --verbosity normal
 
     - name: Pack
-      run: dotnet pack src/CodeToNeo4j/CodeToNeo4j.csproj --no-restore -c Release -o out /p:Version=${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }}
+      run: dotnet pack src/CodeToNeo4j/CodeToNeo4j.csproj --no-restore -c Release -o out /p:Version=${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
 
     - name: Attest build provenance
       uses: actions/attest-build-provenance@v4
@@ -59,16 +56,16 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: v${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }}
-        name: Release v${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }}
+        tag_name: v${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
+        name: Release v${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
         body: |
           ## Installation
           Install from Nuget:
-          [![NuGet](https://img.shields.io/badge/nuget-v${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }}-blue)](https://www.nuget.org/packages/CodeToNeo4j/${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }})
+          [![NuGet](https://img.shields.io/badge/nuget-v${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}-blue)](https://www.nuget.org/packages/CodeToNeo4j/${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }})
 
           Install from CLI:
           ```bash
-          dotnet tool install --global CodeToNeo4j --version ${{ env.MAJOR }}.${{ env.MINOR }}.${{ github.run_number }}
+          dotnet tool install --global CodeToNeo4j --version ${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
           ```
           ## Provenance
           | Commit | Build |


### PR DESCRIPTION
## Summary

Removes the hardcoded `MAJOR` and `MINOR` environment variables from the `release.yml` workflow `env` block and replaces all references with `${{ vars.MAJOR }}` / `${{ vars.MINOR }}`. The repository variables have been seeded to their current values (`1` and `1`) via the `gh` CLI.

## Issue

Resolves #150

## Checklist

- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change