### PR TITLE
fix: enable clean checkout in all workflows to prevent package buildup

### DIFF
--- a/.github/workflows/index-to-neo4j.yml
+++ b/.github/workflows/index-to-neo4j.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          clean: false
+          clean: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 1
-        clean: false
+        clean: true
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 1
-          clean: false
+          clean: true
 
       - name: Setup .NET (use global.json)
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 1
-        clean: false
+        clean: true
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary

Set `clean: true` on the `actions/checkout` step in all four workflows. Self-hosted runners were accumulating build artifacts and packages between runs due to `clean: false`, causing potential disk pressure and non-reproducible builds.

Resolves #161

## Checklist

- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change