### PR TITLE
refactor: extract inline workflow run/script blocks into .github/scripts

### DIFF
--- a/.github/scripts/index-to-neo4j_install-codetoneo4j.sh
+++ b/.github/scripts/index-to-neo4j_install-codetoneo4j.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet tool update --global CodeToNeo4j
+echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"

--- a/.github/scripts/index-to-neo4j_run-codetoneo4j.sh
+++ b/.github/scripts/index-to-neo4j_run-codetoneo4j.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+codetoneo4j \
+  --sln ./CodeToNeo4j.slnx \
+  --uri bolt://192.168.4.135:7689 \
+  --user neo4j \
+  --database CodeToNeo4j \
+  --password "$NEO4J_PASSWORD" \
+  --diff-base "$DIFF_BASE"

--- a/.github/scripts/pr-requirements_check-issue-reference.js
+++ b/.github/scripts/pr-requirements_check-issue-reference.js
@@ -1,0 +1,14 @@
+module.exports = async ({ github, context, core }) => {
+  const { data: pr } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number
+  });
+
+  const body = pr.body || '';
+  if (!/^Resolves #[0-9]+/m.test(body)) {
+    core.setFailed("PR body must contain 'Resolves #<issue-number>' (e.g. 'Resolves #42').");
+    return;
+  }
+  core.info('Issue reference found.');
+};

--- a/.github/scripts/pr-requirements_check-label.sh
+++ b/.github/scripts/pr-requirements_check-label.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+label_count=$(echo "$LABELS" | jq 'length')
+if [ "$label_count" -eq 0 ]; then
+  echo "::error::This PR requires at least one label before it can be merged."
+  exit 1
+fi
+echo "Labels found: $(echo "$LABELS" | jq -r '[.[].name] | join(", ")')"

--- a/.github/scripts/pr-requirements_check-rebased-checkbox.sh
+++ b/.github/scripts/pr-requirements_check-rebased-checkbox.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exempt_senders="dependabot"
+
+for s in $exempt_senders; do
+  if [ "$SENDER" = "$s" ] || echo "$SENDER" | grep -qi "^${s}"; then
+    echo "Sender '$SENDER' is exempt from rebased checkbox. Skipping."
+    exit 0
+  fi
+done
+
+if ! echo "$BODY" | grep -qF -- '- [x] Rebased on top of main'; then
+  echo "::error::The 'Rebased on top of main' checkbox must be checked before merging."
+  exit 1
+fi
+echo "Rebased checkbox is checked."

--- a/.github/scripts/pr-requirements_check-tests-checkbox.sh
+++ b/.github/scripts/pr-requirements_check-tests-checkbox.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exempt_senders="renovate dependabot"
+exempt_labels="breaking-change build chore ci dependencies dependency skip-changelog"
+
+for s in $exempt_senders; do
+  if [ "$SENDER" = "$s" ] || echo "$SENDER" | grep -qi "^${s}"; then
+    echo "Sender '$SENDER' is exempt from tests checkbox. Skipping."
+    exit 0
+  fi
+done
+
+label_names=$(echo "$LABELS" | jq -r '[.[].name] | join(" ")')
+for l in $exempt_labels; do
+  if echo " $label_names " | grep -qF " $l "; then
+    echo "Label '$l' is exempt from tests checkbox. Skipping."
+    exit 0
+  fi
+done
+
+if ! echo "$BODY" | grep -qF -- '- [x] Tests have been added or updated'; then
+  echo "::error::The 'Tests have been added or updated' checkbox must be checked before merging."
+  exit 1
+fi
+echo "Tests checkbox is checked."

--- a/.github/scripts/pr-requirements_create-and-link-issue.js
+++ b/.github/scripts/pr-requirements_create-and-link-issue.js
@@ -1,0 +1,65 @@
+module.exports = async ({ github, context, core }) => {
+  const prNumber = context.payload.pull_request.number;
+
+  // Always fetch the latest PR body from the API to avoid stale payload data
+  const { data: pr } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: prNumber
+  });
+
+  // Determine labels for the tracking issue (mirror breaking-change from PR)
+  const issueLabels = ['dependencies', 'renovate'];
+  const prLabels = pr.labels.map(l => l.name);
+  if (prLabels.includes('breaking-change')) {
+    issueLabels.push('breaking-change');
+  }
+
+  // Search for an existing tracking issue for this PR
+  const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:issue label:renovate "Tracking issue for Renovate PR #${prNumber}"`;
+  const searchResult = await github.rest.search.issuesAndPullRequests({ q: searchQuery });
+
+  let issueNumber;
+  if (searchResult.data.total_count > 0) {
+    issueNumber = searchResult.data.items[0].number;
+    core.info(`Found existing tracking issue #${issueNumber} for PR #${prNumber}`);
+
+    // Ensure breaking-change label is synced to existing issue
+    if (prLabels.includes('breaking-change')) {
+      const existingIssue = searchResult.data.items[0];
+      const existingLabels = existingIssue.labels.map(l => l.name);
+      if (!existingLabels.includes('breaking-change')) {
+        await github.rest.issues.addLabels({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: issueNumber,
+          labels: ['breaking-change']
+        });
+        core.info(`Added breaking-change label to existing issue #${issueNumber}`);
+      }
+    }
+  } else {
+    const issue = await github.rest.issues.create({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      title: pr.title,
+      body: `Tracking issue for Renovate PR #${prNumber}.`,
+      labels: issueLabels
+    });
+    issueNumber = issue.data.number;
+    core.info(`Created tracking issue #${issueNumber} for PR #${prNumber}`);
+  }
+
+  // Strip any existing Resolves line, then always prepend the correct one
+  const body = (pr.body || '').replace(/^Resolves #\d+\s*/m, '').trimStart();
+  const updatedBody = `Resolves #${issueNumber}\n\n${body}`;
+
+  await github.rest.pulls.update({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: prNumber,
+    body: updatedBody
+  });
+
+  core.info(`Linked PR #${prNumber} to issue #${issueNumber}`);
+};

--- a/.github/scripts/release_build.sh
+++ b/.github/scripts/release_build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet build --no-restore -c Release /p:Version="$VERSION"

--- a/.github/scripts/release_pack.sh
+++ b/.github/scripts/release_pack.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet pack src/CodeToNeo4j/CodeToNeo4j.csproj --no-restore -c Release -o out /p:Version="$VERSION"

--- a/.github/scripts/release_push-to-github-packages.sh
+++ b/.github/scripts/release_push-to-github-packages.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet nuget push out/*.nupkg --source "https://nuget.pkg.github.com/$REPOSITORY_OWNER/index.json" --api-key "$GITHUB_TOKEN"

--- a/.github/scripts/release_push-to-nuget.sh
+++ b/.github/scripts/release_push-to-nuget.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet nuget push out/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key "$NUGET_KEY"

--- a/.github/scripts/release_restore-dependencies.sh
+++ b/.github/scripts/release_restore-dependencies.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet restore

--- a/.github/scripts/release_test.sh
+++ b/.github/scripts/release_test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet test --no-build -c Release --verbosity normal

--- a/.github/scripts/renovate_configure-git-user.sh
+++ b/.github/scripts/renovate_configure-git-user.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git config --global user.email 'chase.florell@gmail.com'
+git config --global user.name 'Chase Florell'

--- a/.github/scripts/renovate_install-dependencies.sh
+++ b/.github/scripts/renovate_install-dependencies.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm ci --loglevel=error

--- a/.github/scripts/renovate_run-renovate.sh
+++ b/.github/scripts/renovate_run-renovate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npx renovate

--- a/.github/scripts/verify_dart-test.sh
+++ b/.github/scripts/verify_dart-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dart pub get
+dart test --coverage=coverage --reporter=compact --file-reporter=json:dart-test-results.json
+dart pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib

--- a/.github/scripts/verify_dotnet-build.sh
+++ b/.github/scripts/verify_dotnet-build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet build --no-restore -c Release

--- a/.github/scripts/verify_dotnet-restore.sh
+++ b/.github/scripts/verify_dotnet-restore.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dotnet restore

--- a/.github/scripts/verify_dotnet-test.sh
+++ b/.github/scripts/verify_dotnet-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rm -rf ./TestResults
+dotnet test --no-build -c Release --verbosity normal --logger "trx" --results-directory ./TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover

--- a/.github/workflows/index-to-neo4j.yml
+++ b/.github/workflows/index-to-neo4j.yml
@@ -20,16 +20,10 @@ jobs:
           global-json-file: global.json
 
       - name: Install CodeToNeo4j
-        run: |
-          dotnet tool update --global CodeToNeo4j
-          echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+        run: ./.github/scripts/index-to-neo4j_install-codetoneo4j.sh
 
       - name: Run CodeToNeo4j
-        run: |
-          codetoneo4j \
-            --sln ./CodeToNeo4j.slnx \
-            --uri bolt://192.168.4.135:7689 \
-            --user neo4j \
-            --database CodeToNeo4j \
-            --password ${{ secrets.NEO4J_PASSWORD }} \
-            --diff-base ${{ github.event.before }}
+        env:
+          NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
+          DIFF_BASE: ${{ github.event.before }}
+        run: ./.github/scripts/index-to-neo4j_run-codetoneo4j.sh

--- a/.github/workflows/pr-requirements.yml
+++ b/.github/workflows/pr-requirements.yml
@@ -15,75 +15,19 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: self-hosted
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          clean: true
+
       - name: Create issue and update PR body
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           retries: 3
           script: |
-            const prNumber = context.payload.pull_request.number;
-
-            // Always fetch the latest PR body from the API to avoid stale payload data
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-
-            // Determine labels for the tracking issue (mirror breaking-change from PR)
-            const issueLabels = ['dependencies', 'renovate'];
-            const prLabels = pr.labels.map(l => l.name);
-            if (prLabels.includes('breaking-change')) {
-              issueLabels.push('breaking-change');
-            }
-
-            // Search for an existing tracking issue for this PR
-            const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:issue label:renovate "Tracking issue for Renovate PR #${prNumber}"`;
-            const searchResult = await github.rest.search.issuesAndPullRequests({ q: searchQuery });
-
-            let issueNumber;
-            if (searchResult.data.total_count > 0) {
-              issueNumber = searchResult.data.items[0].number;
-              core.info(`Found existing tracking issue #${issueNumber} for PR #${prNumber}`);
-
-              // Ensure breaking-change label is synced to existing issue
-              if (prLabels.includes('breaking-change')) {
-                const existingIssue = searchResult.data.items[0];
-                const existingLabels = existingIssue.labels.map(l => l.name);
-                if (!existingLabels.includes('breaking-change')) {
-                  await github.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber,
-                    labels: ['breaking-change']
-                  });
-                  core.info(`Added breaking-change label to existing issue #${issueNumber}`);
-                }
-              }
-            } else {
-              const issue = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: pr.title,
-                body: `Tracking issue for Renovate PR #${prNumber}.`,
-                labels: issueLabels
-              });
-              issueNumber = issue.data.number;
-              core.info(`Created tracking issue #${issueNumber} for PR #${prNumber}`);
-            }
-
-            // Strip any existing Resolves line, then always prepend the correct one
-            const body = (pr.body || '').replace(/^Resolves #\d+\s*/m, '').trimStart();
-            const updatedBody = `Resolves #${issueNumber}\n\n${body}`;
-
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              body: updatedBody
-            });
-
-            core.info(`Linked PR #${prNumber} to issue #${issueNumber}`);
+            const script = require('./.github/scripts/pr-requirements_create-and-link-issue.js')
+            await script({github, context, core})
 
   check-label:
     name: Check for at least one label
@@ -92,13 +36,7 @@ jobs:
       - name: Check for at least one label
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels) }}
-        run: |
-          label_count=$(echo "$LABELS" | jq 'length')
-          if [ "$label_count" -eq 0 ]; then
-            echo "::error::This PR requires at least one label before it can be merged."
-            exit 1
-          fi
-          echo "Labels found: $(echo "$LABELS" | jq -r '[.[].name] | join(", ")')"
+        run: ./.github/scripts/pr-requirements_check-label.sh
 
   check-issue-reference:
     name: Check for issue reference in PR body
@@ -106,23 +44,18 @@ jobs:
     if: always() && !cancelled()
     runs-on: self-hosted
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          clean: true
+
       - name: Check for issue number in Resolves field
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
-            });
-
-            const body = pr.body || '';
-            if (!/^Resolves #[0-9]+/m.test(body)) {
-              core.setFailed("PR body must contain 'Resolves #<issue-number>' (e.g. 'Resolves #42').");
-              return;
-            }
-            core.info('Issue reference found.');
+            const script = require('./.github/scripts/pr-requirements_check-issue-reference.js')
+            await script({github, context, core})
 
   check-tests-checkbox:
     name: Check that tests checkbox is checked
@@ -133,30 +66,7 @@ jobs:
           BODY: ${{ github.event.pull_request.body }}
           LABELS: ${{ toJson(github.event.pull_request.labels) }}
           SENDER: ${{ github.event.pull_request.user.login }}
-        run: |
-          exempt_senders="renovate dependabot"
-          exempt_labels="breaking-change build chore ci dependencies dependency skip-changelog"
-
-          for s in $exempt_senders; do
-            if [ "$SENDER" = "$s" ] || echo "$SENDER" | grep -qi "^${s}"; then
-              echo "Sender '$SENDER' is exempt from tests checkbox. Skipping."
-              exit 0
-            fi
-          done
-
-          label_names=$(echo "$LABELS" | jq -r '[.[].name] | join(" ")')
-          for l in $exempt_labels; do
-            if echo " $label_names " | grep -qF " $l "; then
-              echo "Label '$l' is exempt from tests checkbox. Skipping."
-              exit 0
-            fi
-          done
-
-          if ! echo "$BODY" | grep -qF -- '- [x] Tests have been added or updated'; then
-            echo "::error::The 'Tests have been added or updated' checkbox must be checked before merging."
-            exit 1
-          fi
-          echo "Tests checkbox is checked."
+        run: ./.github/scripts/pr-requirements_check-tests-checkbox.sh
 
   check-rebased-checkbox:
     name: Check that rebased checkbox is checked
@@ -166,18 +76,4 @@ jobs:
         env:
           BODY: ${{ github.event.pull_request.body }}
           SENDER: ${{ github.event.pull_request.user.login }}
-        run: |
-          exempt_senders="dependabot"
-
-          for s in $exempt_senders; do
-            if [ "$SENDER" = "$s" ] || echo "$SENDER" | grep -qi "^${s}"; then
-              echo "Sender '$SENDER' is exempt from rebased checkbox. Skipping."
-              exit 0
-            fi
-          done
-
-          if ! echo "$BODY" | grep -qF -- '- [x] Rebased on top of main'; then
-            echo "::error::The 'Rebased on top of main' checkbox must be checked before merging."
-            exit 1
-          fi
-          echo "Rebased checkbox is checked."
+        run: ./.github/scripts/pr-requirements_check-rebased-checkbox.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,20 @@ jobs:
         global-json-file: global.json
 
     - name: Restore dependencies
-      run: dotnet restore
+      run: ./.github/scripts/release_restore-dependencies.sh
 
     - name: Build
-      run: dotnet build --no-restore -c Release /p:Version=${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
+      env:
+        VERSION: ${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
+      run: ./.github/scripts/release_build.sh
 
     - name: Test
-      run: dotnet test --no-build -c Release --verbosity normal
+      run: ./.github/scripts/release_test.sh
 
     - name: Pack
-      run: dotnet pack src/CodeToNeo4j/CodeToNeo4j.csproj --no-restore -c Release -o out /p:Version=${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
+      env:
+        VERSION: ${{ vars.MAJOR }}.${{ vars.MINOR }}.${{ github.run_number }}
+      run: ./.github/scripts/release_pack.sh
 
     - name: Attest build provenance
       uses: actions/attest-build-provenance@v4
@@ -54,10 +58,14 @@ jobs:
         path: out/*.nupkg
 
     - name: Push to NuGet.org
-      run: dotnet nuget push out/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_KEY }}
+      env:
+        NUGET_KEY: ${{ secrets.NUGET_KEY }}
+      run: ./.github/scripts/release_push-to-nuget.sh
 
     - name: Push to GitHub Packages
-      run: dotnet nuget push out/*.nupkg --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
+      env:
+        REPOSITORY_OWNER: ${{ github.repository_owner }}
+      run: ./.github/scripts/release_push-to-github-packages.sh
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -36,12 +36,10 @@ jobs:
           node-version: '24'
 
       - name: Configure git user for Renovate
-        run: |
-          git config --global user.email 'chase.florell@gmail.com'
-          git config --global user.name 'Chase Florell'
+        run: ./.github/scripts/renovate_configure-git-user.sh
 
       - name: Install dependencies
-        run: npm ci --loglevel=error
+        run: ./.github/scripts/renovate_install-dependencies.sh
 
       - name: Run Renovate
         env:
@@ -49,4 +47,4 @@ jobs:
           TOKEN: ${{ secrets.RENOVATE_TOKEN }}
           RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
-        run: npx renovate
+        run: ./.github/scripts/renovate_run-renovate.sh

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,21 +32,16 @@ jobs:
 
     - name: Dart Test
       working-directory: tools/dart-analyzer
-      run: |
-        dart pub get
-        dart test --coverage=coverage --reporter=compact --file-reporter=json:dart-test-results.json
-        dart pub run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
+      run: ${{ github.workspace }}/.github/scripts/verify_dart-test.sh
 
     - name: .NET Restore
-      run: dotnet restore
+      run: ./.github/scripts/verify_dotnet-restore.sh
 
     - name: .NET Build
-      run: dotnet build --no-restore -c Release
+      run: ./.github/scripts/verify_dotnet-build.sh
 
     - name: .NET Test
-      run: |
-        rm -rf ./TestResults
-        dotnet test --no-build -c Release --verbosity normal --logger "trx" --results-directory ./TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+      run: ./.github/scripts/verify_dotnet-test.sh
 
     - name: Upload Dart Coverage to Codecov
       if: always()


### PR DESCRIPTION
## Summary

Extracts all inline `run:` and `script:` blocks from GitHub Actions workflows into discrete files under `.github/scripts/`, named `<workflow>_<step>` in kebab-case. Secrets and GitHub context values are passed into scripts via `env:` on the step where needed.

**Scripts added (20 total):**

| Script | From |
|---|---|
| `verify_dart-test.sh` | verify.yml — Dart Test |
| `verify_dotnet-restore.sh` | verify.yml — .NET Restore |
| `verify_dotnet-build.sh` | verify.yml — .NET Build |
| `verify_dotnet-test.sh` | verify.yml — .NET Test |
| `index-to-neo4j_install-codetoneo4j.sh` | index-to-neo4j.yml — Install CodeToNeo4j |
| `index-to-neo4j_run-codetoneo4j.sh` | index-to-neo4j.yml — Run CodeToNeo4j |
| `release_restore-dependencies.sh` | release.yml — Restore dependencies |
| `release_build.sh` | release.yml — Build |
| `release_test.sh` | release.yml — Test |
| `release_pack.sh` | release.yml — Pack |
| `release_push-to-nuget.sh` | release.yml — Push to NuGet.org |
| `release_push-to-github-packages.sh` | release.yml — Push to GitHub Packages |
| `renovate_configure-git-user.sh` | renovate.yml — Configure git user |
| `renovate_install-dependencies.sh` | renovate.yml — Install dependencies |
| `renovate_run-renovate.sh` | renovate.yml — Run Renovate |
| `pr-requirements_create-and-link-issue.js` | pr-requirements.yml — Create issue and update PR body |
| `pr-requirements_check-label.sh` | pr-requirements.yml — Check for at least one label |
| `pr-requirements_check-issue-reference.js` | pr-requirements.yml — Check for issue number in Resolves field |
| `pr-requirements_check-tests-checkbox.sh` | pr-requirements.yml — Check that tests checkbox is checked |
| `pr-requirements_check-rebased-checkbox.sh` | pr-requirements.yml — Check that rebased checkbox is checked |

The two pre-existing scripts (`close-associated-issues.js`, `test-summary-comment.js`) were already correctly structured and are unchanged.

Resolves #163

## Checklist

- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change