### PR TITLE
fix: pass GITHUB_TOKEN to release push-to-github-packages script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Push to GitHub Packages
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./.github/scripts/release_push-to-github-packages.sh
 
       - name: Generate Release Notes


### PR DESCRIPTION
## Summary

Add `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the env block of the "Push to GitHub Packages" step in `release.yml`. The script uses `$GITHUB_TOKEN` but it was not being passed after the move from inline commands to shell scripts, causing `unbound variable` failures.

## Issue

Resolves #183

## Checklist

- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change