### PR TITLE
feat: capture XML attribute usages in graph

### DIFF
--- a/src/CodeToNeo4j/FileHandlers/XmlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/XmlHandler.cs
@@ -70,6 +70,30 @@ public class XmlHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapp
 		symbolBuffer.Add(record);
 		relBuffer.Add(new(fileKey, key, "CONTAINS"));
 
+		// Extract attributes
+		foreach (var attr in element.Attributes())
+		{
+			var attrName = attr.Name.LocalName;
+			var attrValue = attr.Value;
+			var attrKey = textSymbolMapper.BuildKey(fileKey, "XmlAttribute", $"{name}.{attrName}", startLine);
+
+			var attrRecord = textSymbolMapper.CreateSymbol(
+				attrKey,
+				attrName,
+				"XmlAttribute",
+				"attribute",
+				$"{name}.{attrName}={attrValue}",
+				fileKey,
+				relativePath,
+				fileNamespace,
+				startLine,
+				documentation: attrValue,
+				language: Language, technology: Technology);
+
+			symbolBuffer.Add(attrRecord);
+			relBuffer.Add(new(key, attrKey, "HAS_ATTRIBUTE"));
+		}
+
 		foreach (var child in element.Elements())
 		{
 			ProcessElement(child, fileKey, relativePath, fileNamespace, symbolBuffer, relBuffer, minAccessibility);

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XmlHandlerTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XmlHandlerTests.cs
@@ -12,20 +12,11 @@ namespace CodeToNeo4j.Tests.FileHandlers;
 
 public class XmlHandlerTests
 {
-	private static IConfigurationService CreateConfigService()
-	{
-		IConfigurationService fake = A.Fake<IConfigurationService>();
-		A.CallTo(() => fake.GetHandlerConfiguration(A<string>._))
-			.Returns(new HandlerConfiguration([".xml"], "xml"));
-		return fake;
-	}
-
 	[Fact]
 	public async Task GivenXmlWithElements_WhenHandleCalled_ThenAddsSymbolsAndRelationships()
 	{
 		// Arrange
-		MockFileSystem fileSystem = new();
-		XmlHandler sut = new(fileSystem, new TextSymbolMapper(), NullLogger<XmlHandler>.Instance, CreateConfigService());
+		var (sut, fileSystem) = CreateSut();
 		var content = @"<root><child>value</child></root>";
 		var filePath = "test.xml";
 		fileSystem.AddFile(filePath, new(content));
@@ -55,5 +46,94 @@ public class XmlHandlerTests
 
 		relBuffer.ShouldContain(r => r.FromKey == "test-file" && r.ToKey == rootSymbol.Key && r.RelType == "CONTAINS");
 		relBuffer.ShouldContain(r => r.FromKey == "test-file" && r.ToKey == childSymbol.Key && r.RelType == "CONTAINS");
+	}
+
+	[Fact]
+	public async Task GivenXmlWithSingleAttribute_WhenHandleCalled_ThenCapturesAsXmlAttribute()
+	{
+		// Arrange
+		var (sut, fileSystem) = CreateSut();
+		var content = @"<root><item name=""foo"" /></root>";
+		var filePath = "test.xml";
+		fileSystem.AddFile(filePath, new(content));
+
+		List<Symbol> symbolBuffer = [];
+		List<Relationship> relBuffer = [];
+
+		// Act
+		await sut.Handle(null, null, "test-repo", "test-file", filePath, filePath, symbolBuffer, relBuffer, Accessibility.Private);
+
+		// Assert
+		var attrSymbol = symbolBuffer.FirstOrDefault(s => s.Kind == "XmlAttribute" && s.Name == "name");
+		attrSymbol.ShouldNotBeNull();
+		attrSymbol.Documentation.ShouldBe("foo");
+		attrSymbol.Fqn.ShouldBe("item.name=foo");
+
+		var itemSymbol = symbolBuffer.First(s => s.Kind == "XmlElement" && s.Name == "item");
+		relBuffer.ShouldContain(r => r.FromKey == itemSymbol.Key && r.ToKey == attrSymbol.Key && r.RelType == "HAS_ATTRIBUTE");
+	}
+
+	[Fact]
+	public async Task GivenXmlWithMultipleAttributes_WhenHandleCalled_ThenCapturesAll()
+	{
+		// Arrange
+		var (sut, fileSystem) = CreateSut();
+		var content = @"<root><PackageReference Include=""Newtonsoft.Json"" Version=""13.0.3"" /></root>";
+		var filePath = "test.xml";
+		fileSystem.AddFile(filePath, new(content));
+
+		List<Symbol> symbolBuffer = [];
+		List<Relationship> relBuffer = [];
+
+		// Act
+		await sut.Handle(null, null, "test-repo", "test-file", filePath, filePath, symbolBuffer, relBuffer, Accessibility.Private);
+
+		// Assert
+		var includeAttr = symbolBuffer.FirstOrDefault(s => s.Kind == "XmlAttribute" && s.Name == "Include");
+		includeAttr.ShouldNotBeNull();
+		includeAttr.Documentation.ShouldBe("Newtonsoft.Json");
+
+		var versionAttr = symbolBuffer.FirstOrDefault(s => s.Kind == "XmlAttribute" && s.Name == "Version");
+		versionAttr.ShouldNotBeNull();
+		versionAttr.Documentation.ShouldBe("13.0.3");
+
+		var pkgRefSymbol = symbolBuffer.First(s => s.Kind == "XmlElement" && s.Name == "PackageReference");
+		relBuffer.ShouldContain(r => r.FromKey == pkgRefSymbol.Key && r.ToKey == includeAttr.Key && r.RelType == "HAS_ATTRIBUTE");
+		relBuffer.ShouldContain(r => r.FromKey == pkgRefSymbol.Key && r.ToKey == versionAttr.Key && r.RelType == "HAS_ATTRIBUTE");
+	}
+
+	[Fact]
+	public async Task GivenXmlWithNoAttributes_WhenHandleCalled_ThenNoXmlAttributeSymbols()
+	{
+		// Arrange
+		var (sut, fileSystem) = CreateSut();
+		var content = @"<root><item>value</item></root>";
+		var filePath = "test.xml";
+		fileSystem.AddFile(filePath, new(content));
+
+		List<Symbol> symbolBuffer = [];
+		List<Relationship> relBuffer = [];
+
+		// Act
+		await sut.Handle(null, null, "test-repo", "test-file", filePath, filePath, symbolBuffer, relBuffer, Accessibility.Private);
+
+		// Assert
+		symbolBuffer.ShouldNotContain(s => s.Kind == "XmlAttribute");
+		relBuffer.ShouldNotContain(r => r.RelType == "HAS_ATTRIBUTE");
+	}
+
+	private static IConfigurationService CreateConfigService()
+	{
+		IConfigurationService fake = A.Fake<IConfigurationService>();
+		A.CallTo(() => fake.GetHandlerConfiguration(A<string>._))
+			.Returns(new HandlerConfiguration([".xml"], "xml"));
+		return fake;
+	}
+
+	private static (XmlHandler sut, MockFileSystem fileSystem) CreateSut()
+	{
+		MockFileSystem fileSystem = new();
+		XmlHandler sut = new(fileSystem, new TextSymbolMapper(), NullLogger<XmlHandler>.Instance, CreateConfigService());
+		return (sut, fileSystem);
 	}
 }


### PR DESCRIPTION
## Summary

Captures all XML element attributes as `XmlAttribute` symbols with `HAS_ATTRIBUTE` relationships from their parent `XmlElement`. Each attribute stores the attribute name and raw value. No filtering is applied — all attributes on XML elements are considered meaningful.

## Issue

Resolves #176

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change