### PR TITLE
refactor: extract shared XML attribute extraction

### DIFF
--- a/src/CodeToNeo4j/FileHandlers/XamlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/XamlHandler.cs
@@ -127,7 +127,7 @@ public partial class XamlHandler(
 			relBuffer.Add(new(fileKey, symbolKey, "CONTAINS"));
 		}
 
-		// Extract potential event handlers and property attributes
+		// Extract event handlers
 		foreach (var attr in element.Attributes())
 		{
 			if (IsEventHandler(attr.Name.LocalName))
@@ -153,33 +153,18 @@ public partial class XamlHandler(
 					relBuffer.Add(new(symbolKey, handlerKey, "BINDS_TO"));
 				}
 			}
-			else if (IsPropertyAttribute(attr))
-			{
-				if (Accessibility.Public >= minAccessibility)
-				{
-					var attrName = attr.Name.LocalName;
-					var attrValue = attr.Value;
-					var bindingPath = ExtractBindingPath(attrValue);
-					var attrKey = textSymbolMapper.BuildKey(fileKey, "XamlAttribute", $"{name}.{attrName}", startLine);
+		}
 
-					var attrRecord = textSymbolMapper.CreateSymbol(
-						attrKey,
-						attrName,
-						"XamlAttribute",
-						"attribute",
-						$"{name}.{attrName}={attrValue}",
-						fileKey,
-						relativePath,
-						fileNamespace,
-						startLine,
-						documentation: attrValue,
-						comments: bindingPath,
-						language: Language, technology: Technology);
-
-					symbolBuffer.Add(attrRecord);
-					relBuffer.Add(new(symbolKey, attrKey, "SETS_PROPERTY"));
-				}
-			}
+		// Extract property attributes
+		if (Accessibility.Public >= minAccessibility)
+		{
+			XmlAttributeExtractor.ExtractAttributes(
+				element, name, symbolKey, startLine,
+				fileKey, relativePath, fileNamespace,
+				textSymbolMapper, symbolBuffer, relBuffer,
+				"XamlAttribute", "SETS_PROPERTY",
+				skipPredicate: ShouldSkipAttribute, commentExtractor: ExtractBindingPath,
+				Language, Technology);
 		}
 
 		foreach (var child in element.Elements())
@@ -196,21 +181,27 @@ public partial class XamlHandler(
 		);
 	}
 
-	private static bool IsPropertyAttribute(XAttribute attr)
+	private static bool ShouldSkipAttribute(XAttribute attr)
 	{
 		// Skip namespace declarations (xmlns:x="..." or xmlns="...")
 		if (attr.IsNamespaceDeclaration)
 		{
-			return false;
+			return true;
 		}
 
 		// Skip x:-prefixed attributes (x:Class, x:Name, x:Key, etc.)
 		if (_xamlNamespaces.Contains(attr.Name.NamespaceName))
 		{
-			return false;
+			return true;
 		}
 
-		return true;
+		// Skip event handlers (already captured separately)
+		if (IsEventHandler(attr.Name.LocalName))
+		{
+			return true;
+		}
+
+		return false;
 	}
 
 	internal static string? ExtractBindingPath(string value)

--- a/src/CodeToNeo4j/FileHandlers/XmlAttributeExtractor.cs
+++ b/src/CodeToNeo4j/FileHandlers/XmlAttributeExtractor.cs
@@ -1,0 +1,55 @@
+using System.Xml.Linq;
+using CodeToNeo4j.Graph;
+
+namespace CodeToNeo4j.FileHandlers;
+
+internal static class XmlAttributeExtractor
+{
+	internal static void ExtractAttributes(
+		XElement element,
+		string elementName,
+		string parentKey,
+		int startLine,
+		string fileKey,
+		string relativePath,
+		string? fileNamespace,
+		ITextSymbolMapper textSymbolMapper,
+		ICollection<Symbol> symbolBuffer,
+		ICollection<Relationship> relBuffer,
+		string kindToken,
+		string relType,
+		Func<XAttribute, bool>? skipPredicate,
+		Func<string, string?>? commentExtractor,
+		string language,
+		string technology)
+	{
+		foreach (var attr in element.Attributes())
+		{
+			if (skipPredicate != null && skipPredicate(attr))
+			{
+				continue;
+			}
+
+			var attrName = attr.Name.LocalName;
+			var attrValue = attr.Value;
+			var attrKey = textSymbolMapper.BuildKey(fileKey, kindToken, $"{elementName}.{attrName}", startLine);
+
+			var attrRecord = textSymbolMapper.CreateSymbol(
+				attrKey,
+				attrName,
+				kindToken,
+				"attribute",
+				$"{elementName}.{attrName}={attrValue}",
+				fileKey,
+				relativePath,
+				fileNamespace,
+				startLine,
+				documentation: attrValue,
+				comments: commentExtractor?.Invoke(attrValue),
+				language: language, technology: technology);
+
+			symbolBuffer.Add(attrRecord);
+			relBuffer.Add(new(parentKey, attrKey, relType));
+		}
+	}
+}

--- a/src/CodeToNeo4j/FileHandlers/XmlHandler.cs
+++ b/src/CodeToNeo4j/FileHandlers/XmlHandler.cs
@@ -70,29 +70,13 @@ public class XmlHandler(IFileSystem fileSystem, ITextSymbolMapper textSymbolMapp
 		symbolBuffer.Add(record);
 		relBuffer.Add(new(fileKey, key, "CONTAINS"));
 
-		// Extract attributes
-		foreach (var attr in element.Attributes())
-		{
-			var attrName = attr.Name.LocalName;
-			var attrValue = attr.Value;
-			var attrKey = textSymbolMapper.BuildKey(fileKey, "XmlAttribute", $"{name}.{attrName}", startLine);
-
-			var attrRecord = textSymbolMapper.CreateSymbol(
-				attrKey,
-				attrName,
-				"XmlAttribute",
-				"attribute",
-				$"{name}.{attrName}={attrValue}",
-				fileKey,
-				relativePath,
-				fileNamespace,
-				startLine,
-				documentation: attrValue,
-				language: Language, technology: Technology);
-
-			symbolBuffer.Add(attrRecord);
-			relBuffer.Add(new(key, attrKey, "HAS_ATTRIBUTE"));
-		}
+		XmlAttributeExtractor.ExtractAttributes(
+			element, name, key, startLine,
+			fileKey, relativePath, fileNamespace,
+			textSymbolMapper, symbolBuffer, relBuffer,
+			"XmlAttribute", "HAS_ATTRIBUTE",
+			skipPredicate: null, commentExtractor: null,
+			Language, Technology);
 
 		foreach (var child in element.Elements())
 		{

--- a/tests/CodeToNeo4j.Tests/FileHandlers/XmlAttributeExtractorTests.cs
+++ b/tests/CodeToNeo4j.Tests/FileHandlers/XmlAttributeExtractorTests.cs
@@ -1,0 +1,114 @@
+using System.Xml.Linq;
+using CodeToNeo4j.FileHandlers;
+using CodeToNeo4j.Graph;
+using Shouldly;
+using Xunit;
+
+namespace CodeToNeo4j.Tests.FileHandlers;
+
+public class XmlAttributeExtractorTests
+{
+	private readonly TextSymbolMapper _mapper = new();
+
+	[Fact]
+	public void GivenElementWithAttributes_WhenExtractAttributes_ThenCreatesSymbolsAndRelationships()
+	{
+		// Arrange
+		XElement element = XElement.Parse(@"<Entry Keyboard=""Email"" Placeholder=""Enter email"" />", LoadOptions.SetLineInfo);
+		List<Symbol> symbols = [];
+		List<Relationship> rels = [];
+
+		// Act
+		XmlAttributeExtractor.ExtractAttributes(
+			element, "Entry", "parent-key", 5,
+			"file-key", "path.xaml", "ns",
+			_mapper, symbols, rels,
+			"TestAttribute", "TEST_REL",
+			skipPredicate: null, commentExtractor: null,
+			"xaml", "dotnet");
+
+		// Assert
+		symbols.Count.ShouldBe(2);
+
+		Symbol keyboardSymbol = symbols.First(s => s.Name == "Keyboard");
+		keyboardSymbol.Kind.ShouldBe("TestAttribute");
+		keyboardSymbol.Class.ShouldBe("attribute");
+		keyboardSymbol.Documentation.ShouldBe("Email");
+		keyboardSymbol.Fqn.ShouldBe("Entry.Keyboard=Email");
+		keyboardSymbol.Comments.ShouldBeNull();
+		keyboardSymbol.Language.ShouldBe("xaml");
+		keyboardSymbol.Technology.ShouldBe("dotnet");
+
+		Symbol placeholderSymbol = symbols.First(s => s.Name == "Placeholder");
+		placeholderSymbol.Documentation.ShouldBe("Enter email");
+
+		rels.Count.ShouldBe(2);
+		rels.ShouldAllBe(r => r.FromKey == "parent-key" && r.RelType == "TEST_REL");
+	}
+
+	[Fact]
+	public void GivenSkipPredicate_WhenExtractAttributes_ThenSkipsMatchingAttributes()
+	{
+		// Arrange
+		XElement element = XElement.Parse(@"<Item skip=""yes"" keep=""no"" />", LoadOptions.SetLineInfo);
+		List<Symbol> symbols = [];
+		List<Relationship> rels = [];
+
+		// Act
+		XmlAttributeExtractor.ExtractAttributes(
+			element, "Item", "parent-key", 1,
+			"file-key", "path.xml", null,
+			_mapper, symbols, rels,
+			"XmlAttribute", "HAS_ATTRIBUTE",
+			skipPredicate: a => a.Name.LocalName == "skip", commentExtractor: null,
+			"xml", "unknown");
+
+		// Assert
+		symbols.Count.ShouldBe(1);
+		symbols[0].Name.ShouldBe("keep");
+	}
+
+	[Fact]
+	public void GivenCommentExtractor_WhenExtractAttributes_ThenAppliesExtractorToValue()
+	{
+		// Arrange
+		XElement element = XElement.Parse(@"<Label Text=""bound-value"" />", LoadOptions.SetLineInfo);
+		List<Symbol> symbols = [];
+		List<Relationship> rels = [];
+
+		// Act
+		XmlAttributeExtractor.ExtractAttributes(
+			element, "Label", "parent-key", 1,
+			"file-key", "path.xaml", null,
+			_mapper, symbols, rels,
+			"XamlAttribute", "SETS_PROPERTY",
+			skipPredicate: null, commentExtractor: v => $"extracted:{v}",
+			"xaml", "dotnet");
+
+		// Assert
+		symbols.Count.ShouldBe(1);
+		symbols[0].Comments.ShouldBe("extracted:bound-value");
+	}
+
+	[Fact]
+	public void GivenElementWithNoAttributes_WhenExtractAttributes_ThenNoSymbolsOrRelationships()
+	{
+		// Arrange
+		XElement element = XElement.Parse(@"<Empty />", LoadOptions.SetLineInfo);
+		List<Symbol> symbols = [];
+		List<Relationship> rels = [];
+
+		// Act
+		XmlAttributeExtractor.ExtractAttributes(
+			element, "Empty", "parent-key", 1,
+			"file-key", "path.xml", null,
+			_mapper, symbols, rels,
+			"XmlAttribute", "HAS_ATTRIBUTE",
+			skipPredicate: null, commentExtractor: null,
+			"xml", "unknown");
+
+		// Assert
+		symbols.ShouldBeEmpty();
+		rels.ShouldBeEmpty();
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the duplicated attribute-to-symbol mapping logic from `XmlHandler` and `XamlHandler` into a shared `XmlAttributeExtractor` utility. Callers supply the kind token, relationship type, an optional skip predicate, and an optional comment extractor. No behavioural change — pure refactor.

- `XmlHandler` calls with no filtering and no comment extraction
- `XamlHandler` calls with `ShouldSkipAttribute` (namespace decls, x:-prefixed, event handlers) and `ExtractBindingPath`

## Issue

Resolves #175

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change