### PR TITLE
ci: make --uri configurable via NEO4J_URI environment variable

### DIFF
--- a/.github/scripts/index-to-neo4j_run-codetoneo4j.sh
+++ b/.github/scripts/index-to-neo4j_run-codetoneo4j.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 codetoneo4j \
   --sln ./CodeToNeo4j.slnx \
-  --uri bolt://192.168.4.135:7687 \
+  --uri "$NEO4J_URI" \
   --user neo4j \
   --database CodeToNeo4j \
   --password "$NEO4J_PASSWORD" \

--- a/.github/workflows/index-to-neo4j.yml
+++ b/.github/workflows/index-to-neo4j.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Run CodeToNeo4j
         env:
+          NEO4J_URI: ${{ vars.NEO4J_URI }}
           NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
           DIFF_BASE: ${{ github.event.before }}
         run: ./.github/scripts/index-to-neo4j_run-codetoneo4j.sh


### PR DESCRIPTION
## Summary

Replace the hard-coded `bolt://192.168.4.135:7687` URI in the CI run script with a `$NEO4J_URI` environment variable, and pass it from a GitHub repository variable (`vars.NEO4J_URI`) in the workflow. The GitHub variable has been created with the current value.

## Issue

Resolves #210

## Checklist

- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change