### PR TITLE
ci: group dart analyzer and test in Renovate to prevent incompatible upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,17 @@
 			]
 		},
 		{
+			"description": "Group Dart analyzer with test so they resolve together",
+			"groupName": "dart analyzer + test",
+			"matchManagers": [
+				"pub"
+			],
+			"matchPackageNames": [
+				"analyzer",
+				"test"
+			]
+		},
+		{
 			"groupName": "FakeItEasy",
 			"matchPackageNames": [
 				"/^FakeItEasy/"


### PR DESCRIPTION
## Summary

Group the `analyzer` and `test` pub packages together in Renovate so they are only bumped when a compatible pair of versions can be resolved.

## Issue

Resolves #253

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change