### PR TITLE
fix: skip gpg signature validation on codecov upload

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -49,6 +49,7 @@ jobs:
           files: tools/dart-analyzer/coverage/lcov.info
           flags: dart
           fail_ci_if_error: false
+          skip_validation: true
 
       - name: Upload .NET Coverage to Codecov
         if: always()
@@ -58,6 +59,7 @@ jobs:
           directory: ./TestResults
           flags: dotnet
           fail_ci_if_error: false
+          skip_validation: true
 
       - name: Collect Test Results
         if: always()


### PR DESCRIPTION
## Summary

- Codecov CLI download step wastes ~90s per upload waiting on gpg keyring lock, then fails anyway ("Could not verify signature")
- Add `skip_validation: true` to both codecov-action steps to bypass gpg entirely

## Issue

Resolves #327

## Checklist

- [x] This PR resolves the linked issue
- [ ] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change

https://claude.ai/code/session_01GVPFPmCwencCbtYHncCfFo