### PR TITLE
ci(web): upload TypeScript coverage to Codecov and include it in the test summary

### DIFF
--- a/.github/scripts/collect-test-results.js
+++ b/.github/scripts/collect-test-results.js
@@ -70,6 +70,29 @@ module.exports = async () => {
 
 	const dartDurationStr = dartHasResults ? `${(dartDurationMs / 1000).toFixed(2)}s` : 'N/A';
 
+	// ── TypeScript (ts-analyzer) results ──────────────────────────────────────────
+
+	const tsResultsFile = path.join(process.cwd(), 'tools', 'ts-analyzer', 'ts-test-results.xml');
+	let tsTotal = 0, tsPassed = 0, tsFailed = 0, tsSkipped = 0, tsDurationMs = 0;
+	let tsHasResults = false;
+
+	const getComment = (content, name) => {
+		const match = content.match(new RegExp(`<!-- ${name} ([\\d.]+) -->`));
+		return match ? parseFloat(match[1]) : 0;
+	};
+
+	if (fs.existsSync(tsResultsFile)) {
+		tsHasResults = true;
+		const content = fs.readFileSync(tsResultsFile, 'utf8');
+		tsTotal = getComment(content, 'tests');
+		tsPassed = getComment(content, 'pass');
+		tsFailed = getComment(content, 'fail') + getComment(content, 'cancelled');
+		tsSkipped = getComment(content, 'skipped');
+		tsDurationMs = getComment(content, 'duration_ms');
+	}
+
+	const tsDurationStr = tsHasResults ? `${(tsDurationMs / 1000).toFixed(2)}s` : 'N/A';
+
 	// ── Combined table ────────────────────────────────────────────────────────────
 
 	const suiteRow = (label, passed, failed, skipped, total, duration) => {
@@ -77,10 +100,10 @@ module.exports = async () => {
 		return `| ${label} | ${status} | ${total} | ${passed} | ${failed} | ${skipped} | ${duration} |`;
 	};
 
-	const totalPassed = dotnetPassed + dartPassed;
-	const totalFailed = dotnetFailed + dartFailed;
-	const totalSkipped = dotnetSkipped + dartSkipped;
-	const totalTests = dotnetTotal + dartTotal;
+	const totalPassed = dotnetPassed + dartPassed + tsPassed;
+	const totalFailed = dotnetFailed + dartFailed + tsFailed;
+	const totalSkipped = dotnetSkipped + dartSkipped + tsSkipped;
+	const totalTests = dotnetTotal + dartTotal + tsTotal;
 	const overallStatus = totalFailed > 0 ? '❌ Failed' : '✅ Passed';
 
 	const tableRows = [
@@ -90,6 +113,9 @@ module.exports = async () => {
 	];
 	if (dartHasResults) {
 		tableRows.push(suiteRow('Dart', dartPassed, dartFailed, dartSkipped, dartTotal, dartDurationStr));
+	}
+	if (tsHasResults) {
+		tableRows.push(suiteRow('TypeScript', tsPassed, tsFailed, tsSkipped, tsTotal, tsDurationStr));
 	}
 	tableRows.push(`| **Total** | **${overallStatus}** | **${totalTests}** | **${totalPassed}** | **${totalFailed}** | **${totalSkipped}** | — |`);
 
@@ -174,6 +200,82 @@ module.exports = async () => {
 
 		coverageSection = coverageRows.join('\n');
 	}
+
+	// ── TypeScript code coverage ────────────────────────────────────────────────
+
+	const tsLcovFile = path.join(process.cwd(), 'tools', 'ts-analyzer', 'coverage', 'lcov.info');
+	let tsCoverageSection = '';
+
+	if (fs.existsSync(tsLcovFile)) {
+		const content = fs.readFileSync(tsLcovFile, 'utf8');
+		let totalLines = 0, coveredLines = 0;
+		let totalBranches = 0, coveredBranches = 0;
+		const fileStats = [];
+
+		let currentFile = null, fileLinesFound = 0, fileLinesHit = 0, fileBranchesFound = 0, fileBranchesHit = 0;
+		const flushFile = () => {
+			if (currentFile) {
+				fileStats.push({
+					name: currentFile,
+					lineRate: fileLinesFound > 0 ? fileLinesHit / fileLinesFound : 0,
+					branchRate: fileBranchesFound > 0 ? fileBranchesHit / fileBranchesFound : 0
+				});
+			}
+		};
+
+		for (const line of content.split('\n')) {
+			if (line.startsWith('SF:')) {
+				flushFile();
+				currentFile = line.slice(3).trim();
+				fileLinesFound = 0; fileLinesHit = 0; fileBranchesFound = 0; fileBranchesHit = 0;
+			} else if (line.startsWith('LF:')) {
+				fileLinesFound = parseInt(line.slice(3)) || 0;
+				totalLines += fileLinesFound;
+			} else if (line.startsWith('LH:')) {
+				fileLinesHit = parseInt(line.slice(3)) || 0;
+				coveredLines += fileLinesHit;
+			} else if (line.startsWith('BRF:')) {
+				fileBranchesFound = parseInt(line.slice(4)) || 0;
+				totalBranches += fileBranchesFound;
+			} else if (line.startsWith('BRH:')) {
+				fileBranchesHit = parseInt(line.slice(4)) || 0;
+				coveredBranches += fileBranchesHit;
+			}
+		}
+		flushFile();
+
+		const lineRate = totalLines > 0 ? (coveredLines / totalLines * 100).toFixed(1) : 'N/A';
+		const branchRate = totalBranches > 0 ? (coveredBranches / totalBranches * 100).toFixed(1) : 'N/A';
+
+		const tsCoverageRows = [
+			'',
+			'### TypeScript Code Coverage',
+			'',
+			'| Metric | Value |',
+			'| --- | --- |',
+			`| **Line Coverage** | ${lineRate}% (${coveredLines}/${totalLines}) |`,
+			`| **Branch Coverage** | ${branchRate}% (${coveredBranches}/${totalBranches}) |`
+		];
+
+		if (fileStats.length > 0) {
+			tsCoverageRows.push(
+				'',
+				'<details>',
+				'<summary>Coverage by file</summary>',
+				'',
+				'| File | Line % | Branch % |',
+				'| --- | --- | --- |'
+			);
+			for (const file of fileStats.sort((a, b) => a.name.localeCompare(b.name))) {
+				tsCoverageRows.push(`| ${file.name} | ${(file.lineRate * 100).toFixed(1)}% | ${(file.branchRate * 100).toFixed(1)}% |`);
+			}
+			tsCoverageRows.push('', '</details>');
+		}
+
+		tsCoverageSection = tsCoverageRows.join('\n');
+	}
+
+	coverageSection = [coverageSection, tsCoverageSection].filter(Boolean).join('\n');
 
 	// ── Write summary artifact ──────────────────────────────────────────────────
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Test TS Analyzer
         working-directory: tools/ts-analyzer
-        run: npm test
+        run: npm run test:ci
 
       - name: Dart Test
         working-directory: tools/dart-analyzer
@@ -61,6 +61,16 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: tools/dart-analyzer/coverage/lcov.info
           flags: dart
+          fail_ci_if_error: false
+          skip_validation: true
+
+      - name: Upload TypeScript Coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: tools/ts-analyzer/coverage/lcov.info
+          flags: typescript
           fail_ci_if_error: false
           skip_validation: true
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build TS Analyzer
         working-directory: tools/ts-analyzer

--- a/.gitignore
+++ b/.gitignore
@@ -239,6 +239,10 @@ FakesAssemblies/
 .ntvs_analysis.dat
 node_modules/
 
+# ts-analyzer test/coverage output
+tools/ts-analyzer/coverage/
+tools/ts-analyzer/ts-test-results.xml
+
 # Typescript v1 declaration files
 typings/
 

--- a/tools/ts-analyzer/package.json
+++ b/tools/ts-analyzer/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outfile=dist/index.js",
     "test": "tsx --test test/models.test.ts test/visitor.test.ts test/analyzer.test.ts test/index.test.ts",
+    "pretest:ci": "mkdir -p coverage",
+    "test:ci": "tsx --test --experimental-test-coverage --test-coverage-include=\"src/**/*.ts\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=ts-test-results.xml --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/models.test.ts test/visitor.test.ts test/analyzer.test.ts test/index.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

This Pull Request attempts to add type script coverage to the code coverage reporting

## Issue

Resolves #372

## Checklist

- [x] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change