### PR TITLE
fix(neo4j): resolve ingestion stall from concurrent unconsumed queries, bound transaction memory, restore flush atomicity

### DIFF
--- a/src/CodeToNeo4j.Dart/Bridge/DartBridgeService.cs
+++ b/src/CodeToNeo4j.Dart/Bridge/DartBridgeService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
@@ -11,18 +12,15 @@ namespace CodeToNeo4j.Dart.Bridge;
 public class DartBridgeService(IFileSystem fileSystem, ILogger<DartBridgeService> logger) : IDartBridgeService
 {
 	[ExcludeFromCodeCoverage(Justification = "Requires live Dart SDK and OS process execution")]
-	public async Task<DartAnalysisResult?> AnalyzeProject(string projectRoot)
-	{
-		if (_cache.TryGetValue(projectRoot, out var cached))
-		{
-			return cached;
-		}
+	public Task<DartAnalysisResult?> AnalyzeProject(string projectRoot) =>
+		_cache.GetOrAdd(projectRoot, key => new Lazy<Task<DartAnalysisResult?>>(() => AnalyzeProjectCore(key))).Value;
 
+	private async Task<DartAnalysisResult?> AnalyzeProjectCore(string projectRoot)
+	{
 		var dartExecutable = FindDartExecutable();
 		if (dartExecutable is null)
 		{
 			logger.LogWarning("Dart SDK not found on PATH. Skipping Dart analysis for {ProjectRoot}", projectRoot);
-			_cache[projectRoot] = null;
 			return null;
 		}
 
@@ -30,14 +28,12 @@ public class DartBridgeService(IFileSystem fileSystem, ILogger<DartBridgeService
 		if (bridgeDir is null)
 		{
 			logger.LogWarning("Failed to extract Dart analyzer bridge. Skipping Dart analysis for {ProjectRoot}", projectRoot);
-			_cache[projectRoot] = null;
 			return null;
 		}
 
 		if (!await EnsureDartPubGet(dartExecutable, bridgeDir).ConfigureAwait(false))
 		{
 			logger.LogWarning("dart pub get failed for the analyzer bridge. Skipping Dart analysis for {ProjectRoot}", projectRoot);
-			_cache[projectRoot] = null;
 			return null;
 		}
 
@@ -61,19 +57,21 @@ public class DartBridgeService(IFileSystem fileSystem, ILogger<DartBridgeService
 			if (process is null)
 			{
 				logger.LogWarning("Failed to start Dart analyzer bridge process");
-				_cache[projectRoot] = null;
 				return null;
 			}
 
 			var stdoutTask = process.StandardOutput.ReadToEndAsync();
 			var stderrTask = process.StandardError.ReadToEndAsync();
 
-			var completed = process.WaitForExit((int)_defaultTimeout.TotalMilliseconds);
-			if (!completed)
+			using CancellationTokenSource cts = new(_defaultTimeout);
+			try
+			{
+				await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
 			{
 				process.Kill(true);
 				logger.LogWarning("Dart analyzer bridge timed out after {Timeout}", _defaultTimeout);
-				_cache[projectRoot] = null;
 				return null;
 			}
 
@@ -86,20 +84,17 @@ public class DartBridgeService(IFileSystem fileSystem, ILogger<DartBridgeService
 			if (process.ExitCode != 0)
 			{
 				logger.LogWarning("Dart analyzer bridge exited with code {ExitCode}", process.ExitCode);
-				_cache[projectRoot] = null;
 				return null;
 			}
 
 			var stdout = await stdoutTask.ConfigureAwait(false);
 			var result = JsonSerializer.Deserialize<DartAnalysisResult>(stdout);
-			_cache[projectRoot] = result;
 			logger.LogInformation("Dart analysis complete: {FileCount} files analyzed", result?.Files.Count ?? 0);
 			return result;
 		}
 		catch (Exception ex)
 		{
 			logger.LogWarning(ex, "Error running Dart analyzer bridge for {ProjectRoot}", projectRoot);
-			_cache[projectRoot] = null;
 			return null;
 		}
 	}
@@ -251,8 +246,12 @@ public class DartBridgeService(IFileSystem fileSystem, ILogger<DartBridgeService
 			}
 
 			var stderrTask = process.StandardError.ReadToEndAsync();
-			var completed = process.WaitForExit(60_000);
-			if (!completed)
+			using CancellationTokenSource cts = new(TimeSpan.FromSeconds(60));
+			try
+			{
+				await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
 			{
 				process.Kill(true);
 				logger.LogWarning("dart pub get timed out");
@@ -279,7 +278,7 @@ public class DartBridgeService(IFileSystem fileSystem, ILogger<DartBridgeService
 		}
 	}
 
-	private readonly Dictionary<string, DartAnalysisResult?> _cache = new(StringComparer.OrdinalIgnoreCase);
+	private readonly ConcurrentDictionary<string, Lazy<Task<DartAnalysisResult?>>> _cache = new(StringComparer.OrdinalIgnoreCase);
 	private string? _bridgeDir;
 
 	private static readonly TimeSpan _defaultTimeout = TimeSpan.FromMinutes(5);

--- a/src/CodeToNeo4j.Dart/Bridge/DartBridgeService.cs
+++ b/src/CodeToNeo4j.Dart/Bridge/DartBridgeService.cs
@@ -15,6 +15,7 @@ public class DartBridgeService(IFileSystem fileSystem, ILogger<DartBridgeService
 	public Task<DartAnalysisResult?> AnalyzeProject(string projectRoot) =>
 		_cache.GetOrAdd(projectRoot, key => new Lazy<Task<DartAnalysisResult?>>(() => AnalyzeProjectCore(key))).Value;
 
+	[ExcludeFromCodeCoverage(Justification = "Requires live Dart SDK and OS process execution")]
 	private async Task<DartAnalysisResult?> AnalyzeProjectCore(string projectRoot)
 	{
 		var dartExecutable = FindDartExecutable();

--- a/src/CodeToNeo4j.TypeScript/Bridge/TypeScriptBridgeService.cs
+++ b/src/CodeToNeo4j.TypeScript/Bridge/TypeScriptBridgeService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
@@ -11,18 +12,15 @@ namespace CodeToNeo4j.TypeScript.Bridge;
 public class TypeScriptBridgeService(IFileSystem fileSystem, ILogger<TypeScriptBridgeService> logger) : ITypeScriptBridgeService
 {
 	[ExcludeFromCodeCoverage(Justification = "Requires live Node.js runtime and OS process execution")]
-	public async Task<TsAnalysisResult?> AnalyzeProject(string projectRoot)
-	{
-		if (_cache.TryGetValue(projectRoot, out var cached))
-		{
-			return cached;
-		}
+	public Task<TsAnalysisResult?> AnalyzeProject(string projectRoot) =>
+		_cache.GetOrAdd(projectRoot, key => new Lazy<Task<TsAnalysisResult?>>(() => AnalyzeProjectCore(key))).Value;
 
+	private async Task<TsAnalysisResult?> AnalyzeProjectCore(string projectRoot)
+	{
 		var nodeExecutable = FindNodeExecutable();
 		if (nodeExecutable is null)
 		{
 			logger.LogWarning("Node.js not found on PATH. Skipping TypeScript/JavaScript analysis for {ProjectRoot}", projectRoot);
-			_cache[projectRoot] = null;
 			return null;
 		}
 
@@ -30,7 +28,6 @@ public class TypeScriptBridgeService(IFileSystem fileSystem, ILogger<TypeScriptB
 		if (bridgeDir is null)
 		{
 			logger.LogWarning("Failed to extract TypeScript analyzer bridge. Skipping analysis for {ProjectRoot}", projectRoot);
-			_cache[projectRoot] = null;
 			return null;
 		}
 
@@ -54,19 +51,21 @@ public class TypeScriptBridgeService(IFileSystem fileSystem, ILogger<TypeScriptB
 			if (process is null)
 			{
 				logger.LogWarning("Failed to start TypeScript analyzer bridge process");
-				_cache[projectRoot] = null;
 				return null;
 			}
 
 			var stdoutTask = process.StandardOutput.ReadToEndAsync();
 			var stderrTask = process.StandardError.ReadToEndAsync();
 
-			var completed = process.WaitForExit((int)_defaultTimeout.TotalMilliseconds);
-			if (!completed)
+			using CancellationTokenSource cts = new(_defaultTimeout);
+			try
+			{
+				await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
 			{
 				process.Kill(entireProcessTree: true);
 				logger.LogWarning("TypeScript analyzer bridge timed out after {Timeout}", _defaultTimeout);
-				_cache[projectRoot] = null;
 				return null;
 			}
 
@@ -79,20 +78,17 @@ public class TypeScriptBridgeService(IFileSystem fileSystem, ILogger<TypeScriptB
 			if (process.ExitCode != 0)
 			{
 				logger.LogWarning("TypeScript analyzer bridge exited with code {ExitCode}", process.ExitCode);
-				_cache[projectRoot] = null;
 				return null;
 			}
 
 			var stdout = await stdoutTask.ConfigureAwait(false);
 			var result = JsonSerializer.Deserialize<TsAnalysisResult>(stdout);
-			_cache[projectRoot] = result;
 			logger.LogInformation("TypeScript analysis complete: {FileCount} files analyzed", result?.Files.Count ?? 0);
 			return result;
 		}
 		catch (Exception ex)
 		{
 			logger.LogWarning(ex, "Error running TypeScript analyzer bridge for {ProjectRoot}", projectRoot);
-			_cache[projectRoot] = null;
 			return null;
 		}
 	}
@@ -202,7 +198,7 @@ public class TypeScriptBridgeService(IFileSystem fileSystem, ILogger<TypeScriptB
 		}
 	}
 
-	private readonly Dictionary<string, TsAnalysisResult?> _cache = new(StringComparer.OrdinalIgnoreCase);
+	private readonly ConcurrentDictionary<string, Lazy<Task<TsAnalysisResult?>>> _cache = new(StringComparer.OrdinalIgnoreCase);
 	private string? _bridgeDir;
 
 	private static readonly TimeSpan _defaultTimeout = TimeSpan.FromMinutes(5);

--- a/src/CodeToNeo4j.TypeScript/Bridge/TypeScriptBridgeService.cs
+++ b/src/CodeToNeo4j.TypeScript/Bridge/TypeScriptBridgeService.cs
@@ -15,6 +15,7 @@ public class TypeScriptBridgeService(IFileSystem fileSystem, ILogger<TypeScriptB
 	public Task<TsAnalysisResult?> AnalyzeProject(string projectRoot) =>
 		_cache.GetOrAdd(projectRoot, key => new Lazy<Task<TsAnalysisResult?>>(() => AnalyzeProjectCore(key))).Value;
 
+	[ExcludeFromCodeCoverage(Justification = "Requires live Node.js runtime and OS process execution")]
 	private async Task<TsAnalysisResult?> AnalyzeProjectCore(string projectRoot)
 	{
 		var nodeExecutable = FindNodeExecutable();

--- a/src/CodeToNeo4j/Cypher/DeletePriorSymbols.cypher
+++ b/src/CodeToNeo4j/Cypher/DeletePriorSymbols.cypher
@@ -1,3 +1,4 @@
 UNWIND $fileKeys AS fileKey
 MATCH (f:src__File {key: fileKey})-[:src__DECLARES]->(s:src__Symbol)
+WHERE NOT s.key IN $keepKeys
 DETACH DELETE s

--- a/src/CodeToNeo4j/Graph/IGraphService.cs
+++ b/src/CodeToNeo4j/Graph/IGraphService.cs
@@ -9,7 +9,7 @@ public interface IGraphService
 	Task UpsertCommits(string? repoKey, string solutionRoot, IEnumerable<CommitMetadata> commits, string databaseName);
 	Task UpsertDependencies(string? repoKey, IEnumerable<Dependency> dependencies, string databaseName);
 	Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName);
-	Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName);
+	Task FlushSymbols(IEnumerable<string> fileKeys, IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName);
 	Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName);
 	Task PurgeData(string? repoKey, IEnumerable<string>? includeExtensions, string databaseName, bool purgeDependencies, int batchSize);
 }

--- a/src/CodeToNeo4j/Neo4j/INeo4jFlushService.cs
+++ b/src/CodeToNeo4j/Neo4j/INeo4jFlushService.cs
@@ -5,6 +5,6 @@ namespace CodeToNeo4j.Neo4j;
 public interface INeo4jFlushService
 {
 	Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName);
-	Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName);
+	Task FlushSymbols(IEnumerable<string> fileKeys, IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName);
 	Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName);
 }

--- a/src/CodeToNeo4j/Neo4j/Neo4jFlushService.cs
+++ b/src/CodeToNeo4j/Neo4j/Neo4jFlushService.cs
@@ -15,6 +15,20 @@ public class Neo4jFlushService(
 {
 	internal const int MaxIndexedStringLength = 8000;
 
+	// Caps the row count of any single Cypher UNWIND, independent of the caller's --batch-size.
+	// A single file can produce a burst of symbols/relationships far larger than --batch-size
+	// (e.g. a generated file with thousands of cross-references); without this cap that one
+	// file's flush becomes a single oversized transaction regardless of upstream buffering.
+	internal const int MaxRowsPerQuery = 250;
+
+	private static IEnumerable<Dictionary<string, object?>[]> Chunk(Dictionary<string, object?>[] source, int chunkSize)
+	{
+		for (var i = 0; i < source.Length; i += chunkSize)
+		{
+			yield return source[i..Math.Min(i + chunkSize, source.Length)];
+		}
+	}
+
 	public async Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName)
 	{
 		var fileBatch = files.Select(file => new Dictionary<string, object?>
@@ -47,18 +61,25 @@ public class Neo4jFlushService(
 
 		logger.LogDebug("Flushing {Count} files to Neo4j (Database: {DatabaseName})...", fileBatch.Length, databaseName);
 
-		var fileKeys = fileBatch.Select(f => f["fileKey"]).ToArray();
-
 		await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
-		await session.ExecuteWriteAsync(async tx =>
+
+		// Each chunk commits as its own transaction so Neo4j releases that transaction's memory
+		// before the next chunk starts -- chunking rows within one transaction (as before) doesn't
+		// bound peak transaction memory, since Neo4j tracks write/undo state for the whole
+		// transaction until commit, not per-statement.
+		foreach (var chunk in Chunk(fileBatch, MaxRowsPerQuery))
 		{
-			await tx.RunWithRetry(cypherService.GetCypher(Queries.DeletePriorSymbols), new { fileKeys }).ConfigureAwait(false);
-			await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertFile), new { files = fileBatch }).ConfigureAwait(false);
-		}).ConfigureAwait(false);
+			await session.ExecuteWriteAsync(async tx =>
+			{
+				var filesCursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertFile), new { files = chunk }).ConfigureAwait(false);
+				await filesCursor.ConsumeAsync().ConfigureAwait(false);
+			}).ConfigureAwait(false);
+		}
 	}
 
-	public async Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName)
+	public async Task FlushSymbols(IEnumerable<string> fileKeys, IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName)
 	{
+		var fileKeyArray = fileKeys.ToArray();
 		var symbolArray = symbols.ToArray();
 		var symbolBatch = symbolArray.Select(s => new Dictionary<string, object?>
 		{
@@ -93,43 +114,71 @@ public class Neo4jFlushService(
 			.Where(x => ((string[])x["tags"]!).Length > 0)
 			.ToArray();
 
-		if (symbolBatch.Length == 0 && relBatch.Length == 0)
+		if (symbolBatch.Length == 0 && relBatch.Length == 0 && fileKeyArray.Length == 0)
 		{
 			return;
 		}
 
-		logger.LogDebug("Flushing {SymbolCount} symbols and {RelCount} relationships to Neo4j (Database: {DatabaseName})...", symbolBatch.Length,
-			relBatch.Length, databaseName);
-
-		await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
-		await session.ExecuteWriteAsync(async tx =>
+		if (symbolBatch.Length > 0 || relBatch.Length > 0)
 		{
-			List<Task> tasks = [];
+			logger.LogDebug("Flushing {SymbolCount} symbols and {RelCount} relationships to Neo4j (Database: {DatabaseName})...", symbolBatch.Length,
+				relBatch.Length, databaseName);
 
-			if (symbolBatch.Length > 0)
+			await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
+
+			foreach (var chunk in Chunk(symbolBatch, MaxRowsPerQuery))
 			{
-				tasks.Add(tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertSymbols), new { symbols = symbolBatch }));
+				await session.ExecuteWriteAsync(async tx =>
+				{
+					var symbolsCursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertSymbols), new { symbols = chunk }).ConfigureAwait(false);
+					await symbolsCursor.ConsumeAsync().ConfigureAwait(false);
+				}).ConfigureAwait(false);
 			}
 
-			if (relBatch.Length > 0)
+			foreach (var chunk in Chunk(relBatch, MaxRowsPerQuery))
 			{
-				tasks.Add(tx.RunWithRetry(cypherService.GetCypher(Queries.MergeRelationships), new { rels = relBatch }));
+				await session.ExecuteWriteAsync(async tx =>
+				{
+					var relsCursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.MergeRelationships), new { rels = chunk }).ConfigureAwait(false);
+					await relsCursor.ConsumeAsync().ConfigureAwait(false);
+				}).ConfigureAwait(false);
 			}
 
-			if (tasks.Count > 0)
+			if (tagBatch.Length > 0)
 			{
-				await Task.WhenAll(tasks).ConfigureAwait(false);
+				logger.LogDebug("Upserting namespace tags for {Count} symbols (Database: {DatabaseName})...", tagBatch.Length, databaseName);
+				await using var tagSession = driver.AsyncSession(o => o.WithDatabase(databaseName));
+				foreach (var chunk in Chunk(tagBatch, MaxRowsPerQuery))
+				{
+					await tagSession.ExecuteWriteAsync(async tx =>
+					{
+						var tagsCursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertTags), new { symbolTags = chunk }).ConfigureAwait(false);
+						await tagsCursor.ConsumeAsync().ConfigureAwait(false);
+					}).ConfigureAwait(false);
+				}
 			}
-		}).ConfigureAwait(false);
+		}
 
-		if (tagBatch.Length > 0)
+		if (fileKeyArray.Length > 0)
 		{
-			logger.LogDebug("Upserting namespace tags for {Count} symbols (Database: {DatabaseName})...", tagBatch.Length, databaseName);
-			await using var tagSession = driver.AsyncSession(o => o.WithDatabase(databaseName));
-			await tagSession.ExecuteWriteAsync(async tx =>
+			// Runs only after the replacement symbols/relationships above are fully committed, so a
+			// mid-flush failure leaves stale symbols behind instead of deleting data before its
+			// replacement exists. Only symbols absent from this batch's key set are removed, so
+			// symbols untouched by this flush (e.g. a different file's) are never at risk.
+			// Chunked by file key, same as every other write in this file, so a sweep spanning many
+			// files' worth of existing symbols can't build one unbounded transaction either.
+			var keepKeys = symbolArray.Select(s => s.Key).ToArray();
+			logger.LogDebug("Sweeping stale symbols for {Count} files (Database: {DatabaseName})...", fileKeyArray.Length, databaseName);
+			await using var sweepSession = driver.AsyncSession(o => o.WithDatabase(databaseName));
+			foreach (var chunk in fileKeyArray.Chunk(MaxRowsPerQuery))
 			{
-				await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertTags), new { symbolTags = tagBatch }).ConfigureAwait(false);
-			}).ConfigureAwait(false);
+				await sweepSession.ExecuteWriteAsync(async tx =>
+				{
+					var sweepCursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.DeletePriorSymbols), new { fileKeys = chunk, keepKeys })
+						.ConfigureAwait(false);
+					await sweepCursor.ConsumeAsync().ConfigureAwait(false);
+				}).ConfigureAwait(false);
+			}
 		}
 	}
 
@@ -145,10 +194,13 @@ public class Neo4jFlushService(
 
 		logger.LogDebug("Upserting {Count} dependency URL nodes in database: {DatabaseName}", urlBatch.Length, databaseName);
 		await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
-		await session.ExecuteWriteAsync(async tx =>
+		foreach (var chunk in Chunk(urlBatch, MaxRowsPerQuery))
+		{
+			await session.ExecuteWriteAsync(async tx =>
 			{
-				var cursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertDependencyUrls), new { urls = urlBatch });
+				var cursor = await tx.RunWithRetry(cypherService.GetCypher(Queries.UpsertDependencyUrls), new { urls = chunk });
 				await cursor.ConsumeAsync();
 			}).ConfigureAwait(false);
+		}
 	}
 }

--- a/src/CodeToNeo4j/Neo4j/Neo4jSchemaService.cs
+++ b/src/CodeToNeo4j/Neo4j/Neo4jSchemaService.cs
@@ -76,12 +76,15 @@ public class Neo4jSchemaService(
 		}
 
 		logger.LogDebug("Ensuring schema for database: {DatabaseName}", databaseName);
-		var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
+		await using var session = driver.AsyncSession(o => o.WithDatabase(databaseName));
 		var schema = cypherService.GetCypher(Queries.Schema);
 		var statements = schema.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-		await Task.WhenAll(statements.Select(cypher => session.RunWithRetry(cypher)))
-			.ContinueWith(async _ => await session.DisposeAsync());
+		foreach (var cypher in statements)
+		{
+			var cursor = await session.RunWithRetry(cypher).ConfigureAwait(false);
+			await cursor.ConsumeAsync().ConfigureAwait(false);
+		}
 	}
 
 	private async Task UpsertProject(string repoKey, string databaseName)

--- a/src/CodeToNeo4j/Neo4j/Neo4jService.cs
+++ b/src/CodeToNeo4j/Neo4j/Neo4jService.cs
@@ -102,8 +102,8 @@ public class Neo4jService(
 	public Task FlushFiles(IEnumerable<FileMetaData> files, string databaseName) =>
 		flushService.FlushFiles(files, databaseName);
 
-	public Task FlushSymbols(IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName) =>
-		flushService.FlushSymbols(symbols, relationships, databaseName);
+	public Task FlushSymbols(IEnumerable<string> fileKeys, IEnumerable<Symbol> symbols, IEnumerable<Relationship> relationships, string databaseName) =>
+		flushService.FlushSymbols(fileKeys, symbols, relationships, databaseName);
 
 	public Task UpsertDependencyUrls(IEnumerable<UrlNode> urlNodes, string databaseName) =>
 		flushService.UpsertDependencyUrls(urlNodes, databaseName);

--- a/src/CodeToNeo4j/Solution/SolutionProcessor.cs
+++ b/src/CodeToNeo4j/Solution/SolutionProcessor.cs
@@ -91,7 +91,12 @@ public class SolutionProcessor(
 				}
 			}
 
-			ParallelOptions parallelOptions = new() { MaxDegreeOfParallelism = Math.Max(2, Environment.ProcessorCount) };
+			using CancellationTokenSource consumerFaultCts = new();
+			ParallelOptions parallelOptions = new()
+			{
+				MaxDegreeOfParallelism = Math.Max(2, Environment.ProcessorCount),
+				CancellationToken = consumerFaultCts.Token
+			};
 
 			var discoveredFiles = discoveryService.GetFilesToProcess(solutionRoot, solution, extensionsToInclude);
 			var filesToProcess = FilterFiles(discoveredFiles, diffResult?.ModifiedFiles);
@@ -116,11 +121,26 @@ public class SolutionProcessor(
 
 			var consumerTask = RunConsumer(channel.Reader, totalFiles, databaseName, batchSize);
 
-			await Parallel.ForEachAsync(filesToProcess, parallelOptions, async (file, t) =>
+			// If the consumer faults (e.g. Neo4j becomes unreachable), cancel the producers so they
+			// don't deadlock forever writing to a channel nobody is draining anymore.
+			_ = consumerTask.ContinueWith(
+				_ => consumerFaultCts.Cancel(),
+				CancellationToken.None,
+				TaskContinuationOptions.OnlyOnFaulted,
+				TaskScheduler.Default);
+
+			try
 			{
-				var result = await ProcessFile(solution, file, solutionRoot, repoKey, minAccessibility).ConfigureAwait(false);
-				await channel.Writer.WriteAsync(result, t).ConfigureAwait(false);
-			}).ConfigureAwait(false);
+				await Parallel.ForEachAsync(filesToProcess, parallelOptions, async (file, t) =>
+				{
+					var result = await ProcessFile(solution, file, solutionRoot, repoKey, minAccessibility).ConfigureAwait(false);
+					await channel.Writer.WriteAsync(result, t).ConfigureAwait(false);
+				}).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException) when (consumerFaultCts.IsCancellationRequested)
+			{
+				// Real failure surfaces below when consumerTask is awaited.
+			}
 
 			channel.Writer.Complete();
 			var (totalSymbols, totalRelationships) = await consumerTask.ConfigureAwait(false);
@@ -175,7 +195,7 @@ public class SolutionProcessor(
 			totalSymbols += result.Symbols.Count;
 			totalRelationships += result.Relationships.Count;
 
-			if (fileBuffer.Count >= batchSize || symbolBuffer.Count >= batchSize)
+			if (fileBuffer.Count >= batchSize || symbolBuffer.Count >= batchSize || relBuffer.Count >= batchSize || urlBuffer.Count >= batchSize)
 			{
 				await FlushBuffers(fileBuffer, symbolBuffer, relBuffer, urlBuffer, databaseName).ConfigureAwait(false);
 			}
@@ -194,15 +214,17 @@ public class SolutionProcessor(
 	private async Task FlushBuffers(List<FileMetaData> files, List<Symbol> symbols, List<Relationship> relationships, List<UrlNode> urlNodes,
 		string databaseName)
 	{
+		var fileKeys = files.Select(f => f.FileKey).ToArray();
+
 		if (files.Count > 0)
 		{
 			await graphService.FlushFiles(files, databaseName).ConfigureAwait(false);
 			files.Clear();
 		}
 
-		if (symbols.Count > 0 || relationships.Count > 0)
+		if (fileKeys.Length > 0 || symbols.Count > 0 || relationships.Count > 0)
 		{
-			await graphService.FlushSymbols(symbols, relationships, databaseName).ConfigureAwait(false);
+			await graphService.FlushSymbols(fileKeys, symbols, relationships, databaseName).ConfigureAwait(false);
 			symbols.Clear();
 			relationships.Clear();
 		}

--- a/src/CodeToNeo4j/VersionControl/GitMetadataCache.cs
+++ b/src/CodeToNeo4j/VersionControl/GitMetadataCache.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace CodeToNeo4j.VersionControl;
 
 public class GitMetadataCache : IGitMetadataCache
@@ -13,5 +15,5 @@ public class GitMetadataCache : IGitMetadataCache
 
 	public int Count => _cache.Count;
 
-	private readonly Dictionary<string, FileMetadata> _cache = new(StringComparer.OrdinalIgnoreCase);
+	private readonly ConcurrentDictionary<string, FileMetadata> _cache = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/tests/CodeToNeo4j.Tests/Neo4j/Neo4jFlushServiceTests.cs
+++ b/tests/CodeToNeo4j.Tests/Neo4j/Neo4jFlushServiceTests.cs
@@ -68,7 +68,7 @@ public class Neo4jFlushServiceTests
 		var (sut, driver) = CreateSut();
 
 		// Act
-		await sut.FlushSymbols([], [], "testdb");
+		await sut.FlushSymbols([], [], [], "testdb");
 
 		// Assert
 		A.CallTo(() => driver.AsyncSession()).MustNotHaveHappened();
@@ -83,7 +83,7 @@ public class Neo4jFlushServiceTests
 		var session = SetupSession(driver);
 
 		// Act
-		await sut.FlushSymbols(symbols, [], "testdb");
+		await sut.FlushSymbols([], symbols, [], "testdb");
 
 		// Assert
 		A.CallTo(() => session.ExecuteWriteAsync(A<Func<IAsyncQueryRunner, Task>>._, A<Action<TransactionConfigBuilder>?>._)).MustHaveHappened();
@@ -98,7 +98,7 @@ public class Neo4jFlushServiceTests
 		var session = SetupSession(driver);
 
 		// Act
-		await sut.FlushSymbols([], rels, "testdb");
+		await sut.FlushSymbols([], [], rels, "testdb");
 
 		// Assert
 		A.CallTo(() => session.ExecuteWriteAsync(A<Func<IAsyncQueryRunner, Task>>._, A<Action<TransactionConfigBuilder>?>._)).MustHaveHappened();
@@ -119,12 +119,63 @@ public class Neo4jFlushServiceTests
 		var session = SetupSession(driver);
 
 		// Act
-		await sut.FlushSymbols(symbols, [], "testdb");
+		await sut.FlushSymbols([], symbols, [], "testdb");
 
 		// Assert
 		// 1 for symbols/rels, 1 for tags
 		A.CallTo(() => session.ExecuteWriteAsync(A<Func<IAsyncQueryRunner, Task>>._, A<Action<TransactionConfigBuilder>?>._))
 			.MustHaveHappened(2, Times.Exactly);
+	}
+
+	[Fact]
+	public async Task GivenFileKeys_WhenFlushSymbolsCalled_ThenSweepsStaleSymbolsAfterUpserts()
+	{
+		// Arrange
+		var (sut, driver) = CreateSut();
+		var symbols = new[] { new Symbol("k1", "Foo", "NamedType", "class", "Foo", "Public", "f1", "f1.cs", 1, 10, null, null, "ns") };
+		var session = SetupSession(driver);
+		List<string> callOrder = [];
+		A.CallTo(() => session.ExecuteWriteAsync(A<Func<IAsyncQueryRunner, Task>>._, A<Action<TransactionConfigBuilder>?>._))
+			.Invokes((Func<IAsyncQueryRunner, Task> _, Action<TransactionConfigBuilder>? _) => callOrder.Add("write"));
+
+		// Act
+		await sut.FlushSymbols(["f1"], symbols, [], "testdb");
+
+		// Assert
+		A.CallTo(() => driver.AsyncSession(A<Action<SessionConfigBuilder>>._)).MustHaveHappened(2, Times.Exactly);
+		Assert.Equal(2, callOrder.Count);
+	}
+
+	[Fact]
+	public async Task GivenFileKeysExceedingChunkSize_WhenFlushSymbolsCalled_ThenSweepsInMultipleChunkedTransactions()
+	{
+		// Arrange
+		var (sut, driver) = CreateSut();
+		var symbols = new[] { new Symbol("k1", "Foo", "NamedType", "class", "Foo", "Public", "f1", "f1.cs", 1, 10, null, null, "ns") };
+		var session = SetupSession(driver);
+		var fileKeys = Enumerable.Range(0, Neo4jFlushService.MaxRowsPerQuery + 1).Select(i => $"f{i}").ToArray();
+
+		// Act
+		await sut.FlushSymbols(fileKeys, symbols, [], "testdb");
+
+		// Assert
+		// 1 for the symbol upsert chunk, 2 for the sweep (251 file keys split at MaxRowsPerQuery=250)
+		A.CallTo(() => session.ExecuteWriteAsync(A<Func<IAsyncQueryRunner, Task>>._, A<Action<TransactionConfigBuilder>?>._))
+			.MustHaveHappened(3, Times.Exactly);
+	}
+
+	[Fact]
+	public async Task GivenOnlyFileKeysNoSymbolsOrRels_WhenFlushSymbolsCalled_ThenSweepsStaleSymbols()
+	{
+		// Arrange
+		var (sut, driver) = CreateSut();
+		var session = SetupSession(driver);
+
+		// Act
+		await sut.FlushSymbols(["f1"], [], [], "testdb");
+
+		// Assert
+		A.CallTo(() => session.ExecuteWriteAsync(A<Func<IAsyncQueryRunner, Task>>._, A<Action<TransactionConfigBuilder>?>._)).MustHaveHappened();
 	}
 
 	[Fact]

--- a/tests/CodeToNeo4j.Tests/Neo4j/Neo4jFlushServiceTests.cs
+++ b/tests/CodeToNeo4j.Tests/Neo4j/Neo4jFlushServiceTests.cs
@@ -28,6 +28,21 @@ public class Neo4jFlushServiceTests
 		var session = A.Fake<IAsyncSession>();
 		A.CallTo(() => driver.AsyncSession()).Returns(session);
 		A.CallTo(() => driver.AsyncSession(A<Action<SessionConfigBuilder>>._)).Returns(session);
+
+		// Actually invokes the ExecuteWriteAsync callback (instead of just recording the call), so the
+		// tx.RunWithRetry(...) + cursor.ConsumeAsync() lines inside each callback — the code this PR
+		// added to fix the unconsumed-cursor deadlock — get exercised for real, not just referenced.
+		var cursor = A.Fake<IResultCursor>();
+		A.CallTo(() => cursor.ConsumeAsync()).Returns(A.Fake<IResultSummary>());
+		var runner = A.Fake<IAsyncQueryRunner>();
+		A.CallTo(() => runner.RunAsync(A<string>._, A<object>._)).Returns(cursor);
+		A.CallTo(() => session.ExecuteWriteAsync(A<Func<IAsyncQueryRunner, Task>>._, A<Action<TransactionConfigBuilder>?>._))
+			.ReturnsLazily(async call =>
+			{
+				var work = call.GetArgument<Func<IAsyncQueryRunner, Task>>(0)!;
+				await work(runner);
+			});
+
 		return session;
 	}
 

--- a/tests/CodeToNeo4j.Tests/Neo4j/Neo4jServiceTests.cs
+++ b/tests/CodeToNeo4j.Tests/Neo4j/Neo4jServiceTests.cs
@@ -67,10 +67,11 @@ public class Neo4jServiceTests
 		var rels = new[] { new Relationship("k1", "k2", GraphSchema.Relationships.Contains) };
 
 		// Act
-		await sut.FlushSymbols(symbols, rels, "testdb");
+		await sut.FlushSymbols(["key"], symbols, rels, "testdb");
 
 		// Assert
-		A.CallTo(() => flushService.FlushSymbols(A<IEnumerable<Symbol>>._, A<IEnumerable<Relationship>>._, "testdb")).MustHaveHappenedOnceExactly();
+		A.CallTo(() => flushService.FlushSymbols(A<IEnumerable<string>>._, A<IEnumerable<Symbol>>._, A<IEnumerable<Relationship>>._, "testdb"))
+			.MustHaveHappenedOnceExactly();
 	}
 
 	[Fact]

--- a/tests/CodeToNeo4j.Tests/Solution/SolutionProcessorTests.cs
+++ b/tests/CodeToNeo4j.Tests/Solution/SolutionProcessorTests.cs
@@ -89,7 +89,7 @@ public class SolutionProcessorTests
 		totalSymbols.ShouldBe(1);
 		totalRels.ShouldBe(1);
 		A.CallTo(() => graphService.FlushFiles(A<IEnumerable<FileMetaData>>._, "testdb")).MustHaveHappenedOnceExactly();
-		A.CallTo(() => graphService.FlushSymbols(A<IEnumerable<Symbol>>._, A<IEnumerable<Relationship>>._, "testdb")).MustHaveHappenedOnceExactly();
+		A.CallTo(() => graphService.FlushSymbols(A<IEnumerable<string>>._, A<IEnumerable<Symbol>>._, A<IEnumerable<Relationship>>._, "testdb")).MustHaveHappenedOnceExactly();
 	}
 
 	[Fact]
@@ -119,7 +119,7 @@ public class SolutionProcessorTests
 		// Assert
 		totalSymbols.ShouldBe(3);
 		A.CallTo(() => graphService.FlushFiles(A<IEnumerable<FileMetaData>>._, "testdb")).MustHaveHappened(2, Times.Exactly);
-		A.CallTo(() => graphService.FlushSymbols(A<IEnumerable<Symbol>>._, A<IEnumerable<Relationship>>._, "testdb"))
+		A.CallTo(() => graphService.FlushSymbols(A<IEnumerable<string>>._, A<IEnumerable<Symbol>>._, A<IEnumerable<Relationship>>._, "testdb"))
 			.MustHaveHappened(2, Times.Exactly);
 	}
 
@@ -417,7 +417,7 @@ public class SolutionProcessorTests
 
 		// assert — no flushing happened
 		A.CallTo(() => graphService.FlushFiles(A<IEnumerable<FileMetaData>>._, A<string>._)).MustNotHaveHappened();
-		A.CallTo(() => graphService.FlushSymbols(A<IEnumerable<Symbol>>._, A<IEnumerable<Relationship>>._, A<string>._)).MustNotHaveHappened();
+		A.CallTo(() => graphService.FlushSymbols(A<IEnumerable<string>>._, A<IEnumerable<Symbol>>._, A<IEnumerable<Relationship>>._, A<string>._)).MustNotHaveHappened();
 	}
 
 	[Fact]

--- a/tests/CodeToNeo4j.Tests/Solution/SolutionProcessorTests.cs
+++ b/tests/CodeToNeo4j.Tests/Solution/SolutionProcessorTests.cs
@@ -421,6 +421,53 @@ public class SolutionProcessorTests
 	}
 
 	[Fact]
+	public async Task GivenConsumerFaults_WhenProcessSolutionCalled_ThenCancelsProducersAndPropagatesFailure()
+	{
+		// arrange — enough files that several are still in flight when the consumer faults on the first one
+		var graphService = A.Fake<IGraphService>();
+		var fileService = A.Fake<IFileService>();
+		var fileSystem = A.Fake<IFileSystem>();
+		var vcs = A.Fake<IVersionControlService>();
+		var discoveryService = A.Fake<ISolutionFileDiscoveryService>();
+
+		var files = Enumerable.Range(0, 20).Select(i => new ProcessedFile($"/repo/file{i}.cs")).ToArray();
+
+		A.CallTo(() => fileSystem.Path.GetExtension("/repo")).Returns("");
+		A.CallTo(() => fileSystem.Path.GetFileName(A<string>._)).Returns("repo");
+		A.CallTo(() => fileSystem.Path.DirectorySeparatorChar).Returns('/');
+		A.CallTo(() => fileSystem.Path.AltDirectorySeparatorChar).Returns('/');
+		A.CallTo(() => fileService.NormalizePath("/repo")).Returns("/repo");
+		A.CallTo(() => fileService.GetRelativePath("/repo", A<string>._)).ReturnsLazily(call => ((string)call.Arguments[1]!)["/repo/".Length..]);
+		A.CallTo(() => fileService.InferFileMetadata(A<string>._)).Returns(("key", "ns"));
+		// Slow down producers so most are still mid-flight when the consumer's first flush throws below.
+		A.CallTo(() => fileService.ComputeSha256(A<string>._)).ReturnsLazily(async () =>
+		{
+			await Task.Delay(20);
+			return "hash";
+		});
+		A.CallTo(() => vcs.LoadMetadata("/repo", A<HashSet<string>>._)).Returns(Task.CompletedTask);
+		A.CallTo(() => vcs.GetFileMetadata(A<string>._, "/repo"))
+			.Returns(Task.FromResult(new FileMetadata(DateTimeOffset.Now, DateTimeOffset.Now, [], [], [])));
+		A.CallTo(() => discoveryService.GetFilesToProcess("/repo", null, A<IEnumerable<string>>._))
+			.Returns(files);
+
+		// batchSize=1 forces a flush (and thus the throw below) on the very first result the consumer reads.
+		A.CallTo(() => graphService.FlushFiles(A<IEnumerable<FileMetaData>>._, "testdb"))
+			.Throws(new InvalidOperationException("Neo4j unreachable"));
+
+		var sut = CreateProcessor(
+			graphService,
+			fileService: fileService,
+			fileSystem: fileSystem,
+			versionControlService: vcs,
+			discoveryService: discoveryService);
+
+		// act / assert
+		await Should.ThrowAsync<InvalidOperationException>(
+			() => sut.ProcessSolution("/repo", "repo", null, "testdb", 1, false, Accessibility.Public, [".cs"]));
+	}
+
+	[Fact]
 	public async Task GivenSkipDependenciesTrue_WhenProcessSolutionCalled_ThenSkipsDependencyIngestion()
 	{
 		// arrange

--- a/tools/ts-analyzer/src/analyzer.ts
+++ b/tools/ts-analyzer/src/analyzer.ts
@@ -8,7 +8,15 @@ export async function analyze(projectRoot: string): Promise<AnalysisResult> {
   const normalizedRoot = path.resolve(projectRoot);
   const projectName = readProjectName(normalizedRoot);
 
-  const configPath = ts.findConfigFile(normalizedRoot, ts.sys.fileExists, 'tsconfig.json');
+  // ts.findConfigFile walks UP the directory tree with no ceiling. If normalizedRoot has no
+  // tsconfig.json of its own, it will keep ascending past the project root -- potentially
+  // reaching a home-directory or system-level tsconfig -- and that ancestor's `include`/`files`
+  // patterns would then be parsed and enumerated (via ts.createProgram below) across a directory
+  // tree far broader than this project, before the startsWith(normalizedRoot) filter at output
+  // time discards the irrelevant results. Reject any config found outside normalizedRoot so we
+  // fall back to the bounded glob instead.
+  const foundConfigPath = ts.findConfigFile(normalizedRoot, ts.sys.fileExists, 'tsconfig.json');
+  const configPath = foundConfigPath && path.resolve(foundConfigPath).startsWith(normalizedRoot) ? foundConfigPath : undefined;
 
   let compilerOptions: ts.CompilerOptions;
   let rootFileNames: string[];

--- a/tools/ts-analyzer/test/analyzer.test.ts
+++ b/tools/ts-analyzer/test/analyzer.test.ts
@@ -148,6 +148,27 @@ describe('analyzer - tsconfig handling', () => {
     }
     assert.ok(stderrOutput.includes('Could not read tsconfig.json'));
   });
+
+  it('ignores a tsconfig.json found outside the project root and falls back to the glob', async () => {
+    const parent = fs.mkdtempSync(path.join(tmpDir, 'ancestor-tsconfig-'));
+    // An ancestor tsconfig with an `include` that would match nothing under the child project root
+    // if it were (incorrectly) applied -- proving the fallback glob was used instead when this
+    // still finds the child's own file.
+    fs.writeFileSync(
+      path.join(parent, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { target: 'es2020' }, include: ['nomatch/**'] }),
+      'utf-8',
+    );
+    const dir = path.join(parent, 'child-project');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'main.ts'), 'export class FromChild {}', 'utf-8');
+
+    const result = await analyze(dir);
+
+    const fileResult = result.files['main.ts'];
+    assert.ok(fileResult);
+    assert.ok(fileResult.symbols.some((s) => s.name === 'FromChild'));
+  });
 });
 
 describe('analyzer - project name resolution edge cases', () => {


### PR DESCRIPTION
## Summary

Fixes an ingestion stall that deadlocks on large solutions (`Microsoft.Maui.sln`, 13,056 files, stalled at 61% after 4.5 hours).

Root cause: `Neo4jFlushService.FlushSymbols` ran `UpsertSymbols` and `MergeRelationships` concurrently on the same Neo4j transaction via `Task.WhenAll`, with neither result cursor consumed. The bolt protocol doesn't support concurrent queries on one transaction, so the implicit `DiscardUnconsumed` step on commit hangs draining both streams off one socket — confirmed via a live `dotnet-dump`/`dumpasync` capture during an active stall. Same anti-pattern existed in `Neo4jSchemaService.EnsureSchema`.


## Issue

Resolves #362

## Checklist

- [X] This PR resolves the linked issue
- [x] Tests have been added or updated
- [x] Rebased on top of main
- [ ] This is a breaking change